### PR TITLE
Implement DocumentModel initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "stryker-cli": "^1.0.2",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   }
 }

--- a/src/entities/BlockNode/BlockNode.integration.spec.ts
+++ b/src/entities/BlockNode/BlockNode.integration.spec.ts
@@ -21,7 +21,7 @@ describe('BlockNode integration tests', () => {
       });
   });
 
-  it('should create ValueNode by object marked as value', () => {
+  it('should create ValueNode by object marked as value and update its value', () => {
     const value = {
       [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Value,
       value: 'value',
@@ -47,7 +47,7 @@ describe('BlockNode integration tests', () => {
       });
   });
 
-  it('should create TextNode by passed text node data', () => {
+  it('should create TextNode by passed text node data and insert new text into it', () => {
     const text = {
       value: 'Editor.js is a block-styled editor',
       [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
@@ -71,7 +71,7 @@ describe('BlockNode integration tests', () => {
     });
   });
 
-  it('should create relevant nodes from the array', () => {
+  it('should create relevant nodes from the array and update their values', () => {
     const value = 'value';
     const updatedValue = 'updated value';
     const text = {

--- a/src/entities/BlockNode/BlockNode.integration.spec.ts
+++ b/src/entities/BlockNode/BlockNode.integration.spec.ts
@@ -1,0 +1,103 @@
+import { BlockNode, createDataKey } from './index';
+import { BlockChildType } from './types';
+import { NODE_TYPE_HIDDEN_PROP } from './consts';
+
+describe('BlockNode integration tests', () => {
+  it('should create ValueNode by primitive value', () => {
+    const value = 'value';
+    const newValue = 'updated value';
+    const node = new BlockNode({
+      name: 'blockNode',
+      data: {
+        value,
+      },
+    });
+
+    node.updateValue(createDataKey('value'), newValue);
+
+    expect(node.serialized.data)
+      .toEqual({
+        value: newValue,
+      });
+  });
+
+  it('should create ValueNode by object marked as value', () => {
+    const value = {
+      [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Value,
+      value: 'value',
+    };
+    const newValue = {
+      value: 'updated value',
+    };
+    const node = new BlockNode({
+      name: 'blockNode',
+      data: {
+        value,
+      },
+    });
+
+    node.updateValue(createDataKey('value'), newValue);
+
+    expect(node.serialized.data)
+      .toEqual({
+        value: {
+          ...newValue,
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Value,
+        },
+      });
+  });
+
+  it('should create TextNode by passed text node data', () => {
+    const text = {
+      value: 'Editor.js is a block-styled editor',
+      [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+    };
+    const addedText = ' for rich media web content';
+    const node = new BlockNode({
+      name: 'blockNode',
+      data: {
+        text,
+      },
+    });
+
+    node.insertText(createDataKey('text'), addedText);
+
+    expect(node.serialized.data).toEqual({
+      text: {
+        value: `${text.value}${addedText}`,
+        fragments: [],
+        [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+      },
+    });
+  });
+
+  it('should create relevant nodes from the array', () => {
+    const value = 'value';
+    const updatedValue = 'updated value';
+    const text = {
+      value: 'Editor.js is a block-styled editor',
+      [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+    };
+    const addedText = ' for rich media web content';
+    const node = new BlockNode({
+      name: 'blockNode',
+      data: {
+        array: [value, text],
+      },
+    });
+
+    node.updateValue(createDataKey('array.0'), updatedValue);
+    node.insertText(createDataKey('array.1'), addedText);
+
+    expect(node.serialized.data).toEqual({
+      array: [
+        updatedValue,
+        {
+          value: `${text.value}${addedText}`,
+          fragments: [],
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+        },
+      ],
+    });
+  });
+});

--- a/src/entities/BlockNode/BlockNode.spec.ts
+++ b/src/entities/BlockNode/BlockNode.spec.ts
@@ -6,7 +6,7 @@ import { ValueNode } from '../ValueNode';
 import type { EditorDocument } from '../EditorDocument';
 import type { ValueNodeConstructorParameters } from '../ValueNode';
 import { InlineToolData, InlineToolName, TextNode } from '../inline-fragments';
-import { BlockChildType } from './types';
+import { BlockChildType, BlockNodeDataSerialized } from './types';
 import { NODE_TYPE_HIDDEN_PROP } from './consts';
 
 jest.mock('../BlockTune');
@@ -14,6 +14,13 @@ jest.mock('../BlockTune');
 jest.mock('../inline-fragments/TextNode');
 
 jest.mock('../ValueNode');
+
+const createBlockNodeWithData = (data: BlockNodeDataSerialized): BlockNode => {
+  return new BlockNode({
+    name: createBlockToolName('header'),
+    data,
+  });
+};
 
 describe('BlockNode', () => {
   describe('constructor', () => {
@@ -513,46 +520,18 @@ describe('BlockNode', () => {
   });
 
   describe('.insertText()', () => {
-    let node: BlockNode;
     const dataKey = createDataKey('text');
     const text = 'Some text';
 
-    beforeEach(() => {
-      node = new BlockNode({
-        name: createBlockToolName('header'),
-        data: {
-          [dataKey]: {
-            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-            value: '',
-            fragments: [],
-          },
-          object: {
-            [dataKey]: {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-            array: [
-              {
-                [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-                value: '',
-                fragments: [],
-              },
-            ],
-          },
-          array: [
-            {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-          ],
-        },
-      });
-    });
-
     it('should call .insertText() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'insertText');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.insertText(dataKey, text);
 
@@ -562,6 +541,15 @@ describe('BlockNode', () => {
 
     it('should call .insertText() method of the TextNode in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'insertText');
+      const node = createBlockNodeWithData({
+        object: {
+          [dataKey]: {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        },
+      });
 
       node.insertText(createDataKey(`object.${dataKey}`), text);
 
@@ -571,6 +559,17 @@ describe('BlockNode', () => {
 
     it('should call .insertText() method of the TextNode in an array in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'insertText');
+      const node = createBlockNodeWithData({
+        object: {
+          array: [
+            {
+              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ],
+        },
+      });
 
       node.insertText(createDataKey(`object.array.0`), text);
 
@@ -580,6 +579,15 @@ describe('BlockNode', () => {
 
     it('should call .insertText() method of the TextNode in an array', () => {
       const spy = jest.spyOn(TextNode.prototype, 'insertText');
+      const node = createBlockNodeWithData({
+        array: [
+          {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        ],
+      });
 
       node.insertText(createDataKey(`array.0`), text);
 
@@ -590,6 +598,13 @@ describe('BlockNode', () => {
     it('should pass start index to the .insertText() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'insertText');
       const start = 5;
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.insertText(dataKey, text, start);
 
@@ -599,13 +614,14 @@ describe('BlockNode', () => {
 
     it('should throw an error if node does not exist', () => {
       const key = createDataKey('non-existing-key');
+      const node = createBlockNodeWithData({});
 
       expect(() => node.insertText(key, text))
         .toThrow();
     });
 
     it('should throw an error if node is not a TextNode', () => {
-      node = new BlockNode({
+      const node = new BlockNode({
         name: createBlockToolName('header'),
         data: {
           [dataKey]: new ValueNode({} as ValueNodeConstructorParameters),
@@ -618,45 +634,17 @@ describe('BlockNode', () => {
   });
 
   describe('.removeText()', () => {
-    let node: BlockNode;
     const dataKey = createDataKey('text');
-
-    beforeEach(() => {
-      node = new BlockNode({
-        name: createBlockToolName('header'),
-        data: {
-          [dataKey]: {
-            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-            value: '',
-            fragments: [],
-          },
-          object: {
-            [dataKey]: {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-            array: [
-              {
-                [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-                value: '',
-                fragments: [],
-              },
-            ],
-          },
-          array: [
-            {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-          ],
-        },
-      });
-    });
 
     it('should call .removeText() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.removeText(dataKey);
 
@@ -666,6 +654,15 @@ describe('BlockNode', () => {
 
     it('should call .removeText() method of the TextNode in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
+      const node = createBlockNodeWithData({
+        object: {
+          [dataKey]: {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        },
+      });
 
       node.removeText(createDataKey(`object.${dataKey}`));
 
@@ -675,6 +672,17 @@ describe('BlockNode', () => {
 
     it('should call .removeText() method of the TextNode in an array in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
+      const node = createBlockNodeWithData({
+        object: {
+          array: [
+            {
+              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ],
+        },
+      });
 
       node.removeText(createDataKey(`object.array.0`));
 
@@ -684,6 +692,15 @@ describe('BlockNode', () => {
 
     it('should call .removeText() method of the TextNode in an array', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
+      const node = createBlockNodeWithData({
+        array: [
+          {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        ],
+      });
 
       node.removeText(createDataKey(`array.0`));
 
@@ -694,6 +711,13 @@ describe('BlockNode', () => {
     it('should pass start index to the .removeText() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
       const start = 5;
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.removeText(dataKey, start);
 
@@ -705,6 +729,13 @@ describe('BlockNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'removeText');
       const start = 5;
       const end = 10;
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.removeText(dataKey, start, end);
 
@@ -714,13 +745,20 @@ describe('BlockNode', () => {
 
     it('should throw an error if node does not exist', () => {
       const key = createDataKey('non-existing-key');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       expect(() => node.removeText(key))
         .toThrow();
     });
 
     it('should throw an error if node is not a TextNode', () => {
-      node = new BlockNode({
+      const node = new BlockNode({
         name: createBlockToolName('header'),
         data: {
           [dataKey]: new ValueNode({} as ValueNodeConstructorParameters),
@@ -733,48 +771,20 @@ describe('BlockNode', () => {
   });
 
   describe('.format()', () => {
-    let node: BlockNode;
     const dataKey = createDataKey('text');
     const tool = 'bold' as InlineToolName;
     const start = 5;
     const end = 10;
 
-    beforeEach(() => {
-      node = new BlockNode({
-        name: createBlockToolName('header'),
-        data: {
-          [dataKey]: {
-            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-            value: '',
-            fragments: [],
-          },
-          object: {
-            [dataKey]: {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-            array: [
-              {
-                [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-                value: '',
-                fragments: [],
-              },
-            ],
-          },
-          array: [
-            {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-          ],
-        },
-      });
-    });
-
     it('should call .format() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'format');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.format(dataKey, tool, start, end);
 
@@ -784,6 +794,15 @@ describe('BlockNode', () => {
 
     it('should call .format() method of the TextNode in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'format');
+      const node = createBlockNodeWithData({
+        object: {
+          [dataKey]: {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        },
+      });
 
       node.format(createDataKey(`object.${dataKey}`), tool, start, end);
 
@@ -793,6 +812,17 @@ describe('BlockNode', () => {
 
     it('should call .format() method of the TextNode in an array in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'format');
+      const node = createBlockNodeWithData({
+        object: {
+          array: [
+            {
+              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ],
+        },
+      });
 
       node.format(createDataKey(`object.array.0`), tool, start, end);
 
@@ -802,6 +832,15 @@ describe('BlockNode', () => {
 
     it('should call .format() method of the TextNode in an array', () => {
       const spy = jest.spyOn(TextNode.prototype, 'format');
+      const node = createBlockNodeWithData({
+        array: [
+          {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        ],
+      });
 
       node.format(createDataKey(`array.0`), tool, start, end);
 
@@ -812,6 +851,13 @@ describe('BlockNode', () => {
     it('should pass data to the .format() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'format');
       const data = {} as InlineToolData;
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.format(dataKey, tool, start, end, data);
 
@@ -821,13 +867,20 @@ describe('BlockNode', () => {
 
     it('should throw an error if node does not exist', () => {
       const key = createDataKey('non-existing-key');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       expect(() => node.format(key, tool, start, end))
         .toThrow();
     });
 
     it('should throw an error if node is not a TextNode', () => {
-      node = new BlockNode({
+      const node = new BlockNode({
         name: createBlockToolName('header'),
         data: {
           [dataKey]: new ValueNode({} as ValueNodeConstructorParameters),
@@ -840,48 +893,20 @@ describe('BlockNode', () => {
   });
 
   describe('.unformat()', () => {
-    let node: BlockNode;
     const dataKey = createDataKey('text');
     const tool = 'bold' as InlineToolName;
     const start = 5;
     const end = 10;
 
-    beforeEach(() => {
-      node = new BlockNode({
-        name: createBlockToolName('header'),
-        data: {
-          [dataKey]: {
-            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-            value: '',
-            fragments: [],
-          },
-          object: {
-            [dataKey]: {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-            array: [
-              {
-                [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-                value: '',
-                fragments: [],
-              },
-            ],
-          },
-          array: [
-            {
-              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
-              value: '',
-              fragments: [],
-            },
-          ],
-        },
-      });
-    });
-
     it('should call .unformat() method of the TextNode', () => {
       const spy = jest.spyOn(TextNode.prototype, 'unformat');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       node.unformat(dataKey, tool, start, end);
 
@@ -891,6 +916,15 @@ describe('BlockNode', () => {
 
     it('should call .unformat() method of the TextNode in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'unformat');
+      const node = createBlockNodeWithData({
+        object: {
+          [dataKey]: {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        },
+      });
 
       node.unformat(createDataKey(`object.${dataKey}`), tool, start, end);
 
@@ -900,6 +934,17 @@ describe('BlockNode', () => {
 
     it('should call .unformat() method of the TextNode in an array in an object', () => {
       const spy = jest.spyOn(TextNode.prototype, 'unformat');
+      const node = createBlockNodeWithData({
+        object: {
+          array: [
+            {
+              [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ],
+        },
+      });
 
       node.unformat(createDataKey(`object.array.0`), tool, start, end);
 
@@ -909,6 +954,15 @@ describe('BlockNode', () => {
 
     it('should call .unformat() method of the TextNode in an array', () => {
       const spy = jest.spyOn(TextNode.prototype, 'unformat');
+      const node = createBlockNodeWithData({
+        array: [
+          {
+            [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+            value: '',
+            fragments: [],
+          },
+        ],
+      });
 
       node.unformat(createDataKey('array.0'), tool, start, end);
 
@@ -918,13 +972,20 @@ describe('BlockNode', () => {
 
     it('should throw an error if node does not exist', () => {
       const key = createDataKey('non-existing-key');
+      const node = createBlockNodeWithData({
+        [dataKey]: {
+          [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+          value: '',
+          fragments: [],
+        },
+      });
 
       expect(() => node.unformat(key, tool, start, end))
         .toThrow();
     });
 
     it('should throw an error if node is not a TextNode', () => {
-      node = new BlockNode({
+      const node = new BlockNode({
         name: createBlockToolName('header'),
         data: {
           [dataKey]: new ValueNode({} as ValueNodeConstructorParameters),

--- a/src/entities/BlockNode/BlockNode.spec.ts
+++ b/src/entities/BlockNode/BlockNode.spec.ts
@@ -47,7 +47,8 @@ describe('BlockNode', () => {
 
       const serialized = blockNode.serialized;
 
-      expect(serialized.name).toEqual(blockNodeName);
+      expect(serialized.name)
+        .toEqual(blockNodeName);
     });
 
     it('should call .serialized getter of all tunes associated with the BlockNode', () => {
@@ -73,13 +74,15 @@ describe('BlockNode', () => {
 
       blockNode.serialized;
 
-      expect(spy).toHaveBeenCalledTimes(blockTunesNames.length);
+      expect(spy)
+        .toHaveBeenCalledTimes(blockTunesNames.length);
     });
 
     it('should call .serialized getter of all child ValueNodes associated with the BlockNode', () => {
       const numberOfValueNodes = 2;
 
-      const valueNodes = [ ...Array(numberOfValueNodes).keys() ]
+      const valueNodes = [ ...Array(numberOfValueNodes)
+        .keys() ]
         .reduce((acc, index) => ({
           ...acc,
           [createDataKey(`data-key-${index}c${index}d`)]: index,
@@ -97,13 +100,15 @@ describe('BlockNode', () => {
 
       blockNode.serialized;
 
-      expect(spy).toHaveBeenCalledTimes(numberOfValueNodes);
+      expect(spy)
+        .toHaveBeenCalledTimes(numberOfValueNodes);
     });
 
     it('should call .serialized getter of all child TextNodes associated with the BlockNode', () => {
       const numberOfTextNodes = 3;
 
-      const textNodes = [ ...Array(numberOfTextNodes).keys() ]
+      const textNodes = [ ...Array(numberOfTextNodes)
+        .keys() ]
         .reduce((acc, index) => ({
           ...acc,
           [createDataKey(`data-key-${index}c${index}d`)]: {
@@ -125,7 +130,228 @@ describe('BlockNode', () => {
 
       blockNode.serialized;
 
-      expect(spy).toHaveBeenCalledTimes(numberOfTextNodes);
+      expect(spy)
+        .toHaveBeenCalledTimes(numberOfTextNodes);
+    });
+
+
+    it('should call .serialized getter of ValueNodes in an array', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          items: [ 'value' ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of TextNode in an array', () => {
+      const spy = jest.spyOn(TextNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          items: [
+            {
+              $t: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of ValueNodes in an nested object', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          object: {
+            nestedObject: { value: 'value' },
+          },
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of TextNode in a nested object', () => {
+      const spy = jest.spyOn(TextNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          object: {
+            nestedObject: {
+              text: {
+                $t: BlockChildType.Text,
+                value: '',
+                fragments: [],
+              },
+            },
+          },
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of ValueNodes in an array inside an object', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          object: {
+            array: [ 'value' ],
+          },
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of TextNode in an array inside an object', () => {
+      const spy = jest.spyOn(TextNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          object: {
+            array: [ {
+              text: {
+                $t: BlockChildType.Text,
+                value: '',
+                fragments: [],
+              },
+            } ],
+          },
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of ValueNodes in an object inside an array', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          array: [ { value: 'value' } ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of TextNode in an object inside an array', () => {
+      const spy = jest.spyOn(TextNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          array: [ {
+            object: {
+              text: {
+                $t: BlockChildType.Text,
+                value: '',
+                fragments: [],
+              },
+            },
+          } ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of ValueNodes in a nested array', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          array: [ [ 'value' ] ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of TextNode in a nested array', () => {
+      const spy = jest.spyOn(TextNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          array: [ [
+            {
+              $t: BlockChildType.Text,
+              value: '',
+              fragments: [],
+            },
+          ] ],
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it('should call .serialized getter of object marked as value node', () => {
+      const spy = jest.spyOn(ValueNode.prototype, 'serialized', 'get');
+      const blockNode = new BlockNode({
+        name: createBlockToolName('paragraph'),
+        data: {
+          value: {
+            $t: BlockChildType.Value,
+            property: '',
+          },
+        },
+        parent: {} as EditorDocument,
+      });
+
+      blockNode.serialized;
+
+      expect(spy)
+        .toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/entities/BlockNode/BlockNode.spec.ts
+++ b/src/entities/BlockNode/BlockNode.spec.ts
@@ -415,7 +415,7 @@ describe('BlockNode', () => {
         .toHaveBeenCalledWith(value);
     });
 
-    it('should call .update() method of ValueNode when node is inside an object', () => {
+    it('should call .update() method of ValueNode with passed keypath when node is inside an object', () => {
       const dataKey = createDataKey('data-key-1a2b');
       const value = 'Some value';
 

--- a/src/entities/BlockNode/__mocks__/index.ts
+++ b/src/entities/BlockNode/__mocks__/index.ts
@@ -43,4 +43,11 @@ export class BlockNode {
   public unformat(): void {
     return;
   }
+
+  /**
+   * Mock getter
+   */
+  public get serialized(): void {
+    return;
+  }
 }

--- a/src/entities/BlockNode/consts.ts
+++ b/src/entities/BlockNode/consts.ts
@@ -1,1 +1,4 @@
+/**
+ * Name of hidden property to mark value and text nodes in serialized data
+ */
 export const NODE_TYPE_HIDDEN_PROP = '$t' as const;

--- a/src/entities/BlockNode/consts.ts
+++ b/src/entities/BlockNode/consts.ts
@@ -1,0 +1,1 @@
+export const NODE_TYPE_HIDDEN_PROP = '$t' as const;

--- a/src/entities/BlockNode/index.ts
+++ b/src/entities/BlockNode/index.ts
@@ -12,7 +12,7 @@ import {
   BlockNodeDataSerializedValue,
   BlockChildType,
   ChildNode,
-  BlockNodeDataValue,
+  BlockNodeDataValue
 } from './types';
 import { ValueNode } from '../ValueNode';
 import { InlineToolData, InlineToolName, TextNode, TextNodeSerialized } from '../inline-fragments';
@@ -208,8 +208,9 @@ export class BlockNode {
   }
 
   /**
+   * Initializes BlockNode with passed block data
    *
-   * @param data
+   * @param data - block data
    */
   #initialize(data: BlockNodeDataSerialized): void {
     const map = (value: BlockNodeDataSerializedValue): BlockNodeData | BlockNodeDataValue => {

--- a/src/entities/BlockNode/index.ts
+++ b/src/entities/BlockNode/index.ts
@@ -12,7 +12,7 @@ import {
   BlockNodeDataSerializedValue,
   BlockChildType,
   ChildNode,
-  BlockNodeDataValue
+  BlockNodeDataValue,
 } from './types';
 import { ValueNode } from '../ValueNode';
 import { InlineToolData, InlineToolName, TextNode, TextNodeSerialized } from '../inline-fragments';
@@ -82,10 +82,25 @@ export class BlockNode {
    * Returns serialized object representing the BlockNode
    */
   public get serialized(): BlockNodeSerialized {
+    const map = (data: BlockNodeDataValue): BlockNodeDataSerializedValue => {
+      if (Array.isArray(data)) {
+        return data.map(map) as BlockNodeDataSerialized[];
+      }
+
+      if (data instanceof ValueNode || data instanceof TextNode) {
+        return data.serialized;
+      }
+
+      return Object.fromEntries(
+        Object.entries(data)
+          .map(([key, value]) => ([key, map(value)]))
+      );
+    };
+
     const serializedData = Object.fromEntries(
       Object
         .entries(this.#data)
-        .map(([dataKey, value]) => ([dataKey, value.serialized]))
+        .map(([dataKey, value]) => ([dataKey, map(value)]))
     );
 
     const serializedTunes = Object.fromEntries(

--- a/src/entities/BlockNode/types/BlockChildType.ts
+++ b/src/entities/BlockNode/types/BlockChildType.ts
@@ -1,0 +1,4 @@
+export enum BlockChildType {
+  Value = 'v',
+  Text = 't',
+}

--- a/src/entities/BlockNode/types/BlockNodeConstructorParameters.ts
+++ b/src/entities/BlockNode/types/BlockNodeConstructorParameters.ts
@@ -1,18 +1,17 @@
 import { EditorDocument } from '../../EditorDocument';
-import { BlockTune, BlockTuneName } from '../../BlockTune';
-import { BlockToolName } from './BlockToolName';
-import { BlockNodeData } from './BlockNodeData';
+import { BlockTuneSerialized } from '../../BlockTune';
+import { BlockNodeDataSerialized } from './BlockNodeSerialized';
 
 export interface BlockNodeConstructorParameters {
   /**
    * The name of the tool created a Block
    */
-  name: BlockToolName;
+  name: string;
 
   /**
    * The content of the Block
    */
-  data?: BlockNodeData;
+  data?: BlockNodeDataSerialized;
 
   /**
    * The parent EditorDocument of the BlockNode
@@ -22,5 +21,5 @@ export interface BlockNodeConstructorParameters {
   /**
    * The BlockTunes associated with the BlockNode
    */
-  tunes?: Record<BlockTuneName, BlockTune>;
+  tunes?: Record<string, BlockTuneSerialized>;
 }

--- a/src/entities/BlockNode/types/BlockNodeData.ts
+++ b/src/entities/BlockNode/types/BlockNodeData.ts
@@ -2,8 +2,14 @@ import { DataKey } from './DataKey';
 import { ValueNode } from '../../ValueNode';
 import { TextNode } from '../../inline-fragments';
 
+export type ChildNode = ValueNode | TextNode;
+
 /**
  * Represents a record object containing the data of a block node.
  * Each root node is associated with a specific data key.
  */
-export type BlockNodeData = Record<DataKey, ValueNode | TextNode>;
+export interface BlockNodeData {
+  [key: DataKey]: BlockNodeDataValue;
+}
+
+export type BlockNodeDataValue = ChildNode | ChildNode[] | BlockNodeData | BlockNodeData[];

--- a/src/entities/BlockNode/types/BlockNodeSerialized.ts
+++ b/src/entities/BlockNode/types/BlockNodeSerialized.ts
@@ -1,4 +1,15 @@
 import { BlockTuneSerialized } from '../../BlockTune';
+import { ValueSerialized } from '../../ValueNode/types';
+import { TextNodeSerialized } from '../../inline-fragments';
+
+export type BlockChildNodeSerialized = ValueSerialized | TextNodeSerialized;
+
+export type BlockNodeDataSerializedValue = BlockChildNodeSerialized | BlockChildNodeSerialized[] | BlockNodeDataSerialized | BlockNodeDataSerialized[];
+
+export interface BlockNodeDataSerialized {
+  [key: string]: BlockNodeDataSerializedValue;
+}
+
 
 /**
  * Serialized version of the BlockNode
@@ -12,7 +23,7 @@ export interface BlockNodeSerialized {
   /**
    * The content of the Block
    */
-  data: Record<string, unknown>; // @todo replace unknown type with serialized root node and value node
+  data: BlockNodeDataSerialized;
 
   /**
    * Serialized BlockTunes associated with the BlockNode

--- a/src/entities/BlockNode/types/BlockNodeSerialized.ts
+++ b/src/entities/BlockNode/types/BlockNodeSerialized.ts
@@ -2,10 +2,19 @@ import { BlockTuneSerialized } from '../../BlockTune';
 import { ValueSerialized } from '../../ValueNode/types';
 import { TextNodeSerialized } from '../../inline-fragments';
 
+/**
+ * Union type of serialized BlockNode child nodes
+ */
 export type BlockChildNodeSerialized = ValueSerialized | TextNodeSerialized;
 
+/**
+ * Reccurrent type representing serialized BlockNode data
+ */
 export type BlockNodeDataSerializedValue = BlockChildNodeSerialized | BlockChildNodeSerialized[] | BlockNodeDataSerialized | BlockNodeDataSerialized[];
 
+/**
+ * Root type representing serialized BlockNode data
+ */
 export interface BlockNodeDataSerialized {
   [key: string]: BlockNodeDataSerializedValue;
 }

--- a/src/entities/BlockNode/types/BlockNodeSerialized.ts
+++ b/src/entities/BlockNode/types/BlockNodeSerialized.ts
@@ -28,5 +28,5 @@ export interface BlockNodeSerialized {
   /**
    * Serialized BlockTunes associated with the BlockNode
    */
-  tunes: Record<string, BlockTuneSerialized>;
+  tunes?: Record<string, BlockTuneSerialized>;
 }

--- a/src/entities/BlockNode/types/DataKey.ts
+++ b/src/entities/BlockNode/types/DataKey.ts
@@ -2,6 +2,9 @@ import { create, Nominal } from '../../../utils/Nominal';
 
 /**
  * Base type of the data key field
+ *
+ * DataKeyBase is a string for object properties or a number for array indexes
+ * DataKey could be a compound key path, e.g. 'dataKey.nestedArrayKey.0'
  */
 type DataKeyBase = string | number;
 

--- a/src/entities/BlockNode/types/DataKey.ts
+++ b/src/entities/BlockNode/types/DataKey.ts
@@ -3,7 +3,7 @@ import { create, Nominal } from '../../../utils/Nominal';
 /**
  * Base type of the data key field
  */
-type DataKeyBase = string;
+type DataKeyBase = string | number;
 
 /**
  * Nominal type for the data key field

--- a/src/entities/BlockNode/types/index.ts
+++ b/src/entities/BlockNode/types/index.ts
@@ -1,5 +1,6 @@
 export { BlockNodeConstructorParameters } from './BlockNodeConstructorParameters';
 export { BlockToolName, createBlockToolName } from './BlockToolName';
 export { DataKey, createDataKey } from './DataKey';
-export { BlockNodeData } from './BlockNodeData';
-export { BlockNodeSerialized } from './BlockNodeSerialized';
+export { BlockNodeData, ChildNode, BlockNodeDataValue } from './BlockNodeData';
+export { BlockNodeSerialized, BlockChildNodeSerialized, BlockNodeDataSerialized, BlockNodeDataSerializedValue } from './BlockNodeSerialized';
+export { BlockChildType } from './BlockChildType';

--- a/src/entities/BlockTune/BlockTune.spec.ts
+++ b/src/entities/BlockTune/BlockTune.spec.ts
@@ -7,7 +7,8 @@ describe('BlockTune', () => {
     it('should have empty object as default data value', () => {
       const blockTune = new BlockTune({ name: tuneName });
 
-      expect(blockTune.serialized.data).toEqual({});
+      expect(blockTune.serialized)
+        .toEqual({});
     });
   });
 
@@ -23,9 +24,10 @@ describe('BlockTune', () => {
       blockTune.update('align', 'left');
 
       // Assert
-      expect(blockTune.serialized.data).toEqual({
-        align: 'left',
-      });
+      expect(blockTune.serialized)
+        .toEqual({
+          align: 'left',
+        });
     });
 
     it('should update field in data object by key', () => {
@@ -41,9 +43,10 @@ describe('BlockTune', () => {
       blockTune.update('align', 'right');
 
       // Assert
-      expect(blockTune.serialized.data).toEqual({
-        align: 'right',
-      });
+      expect(blockTune.serialized)
+        .toEqual({
+          align: 'right',
+        });
     });
   });
 
@@ -61,14 +64,12 @@ describe('BlockTune', () => {
       const tuneSerialized = tune.serialized;
 
       // Assert
-      expect(tuneSerialized).toEqual(
-        {
-          name: tuneName,
-          data: {
+      expect(tuneSerialized)
+        .toEqual(
+          {
             background: 'transparent',
-          },
-        }
-      );
+          }
+        );
     });
   });
 });

--- a/src/entities/BlockTune/__mocks__/index.ts
+++ b/src/entities/BlockTune/__mocks__/index.ts
@@ -1,3 +1,5 @@
+import { createBlockTuneName } from '../types';
+
 /**
  * Mock for BlockTune class
  */
@@ -16,3 +18,5 @@ export class BlockTune {
     return;
   }
 }
+
+export { createBlockTuneName };

--- a/src/entities/BlockTune/index.ts
+++ b/src/entities/BlockTune/index.ts
@@ -41,10 +41,7 @@ export class BlockTune {
    * Returns serialized version of the BlockTune.
    */
   public get serialized(): BlockTuneSerialized {
-    return {
-      name: this.#name,
-      data: this.#data,
-    };
+    return this.#data;
   }
 }
 

--- a/src/entities/BlockTune/types/BlockTuneConstructorParameters.ts
+++ b/src/entities/BlockTune/types/BlockTuneConstructorParameters.ts
@@ -1,4 +1,5 @@
 import { BlockTuneName } from './BlockTuneName';
+import { BlockTuneSerialized } from './BlockTuneSerialized';
 
 export interface BlockTuneConstructorParameters {
   /**
@@ -9,5 +10,5 @@ export interface BlockTuneConstructorParameters {
   /**
    * Any additional data associated with the tune
    */
-  data?: Record<string, unknown>;
+  data?: BlockTuneSerialized;
 }

--- a/src/entities/BlockTune/types/BlockTuneSerialized.ts
+++ b/src/entities/BlockTune/types/BlockTuneSerialized.ts
@@ -1,15 +1,4 @@
 /**
  * BlockTuneSerialized represents a serialized version of a BlockTune.
  */
-export interface BlockTuneSerialized {
-  /**
-   * The name of the tune.
-   * Serialized as a string.
-   */
-  name: string;
-
-  /**
-   * Any additional data associated with the tune.
-   */
-  data: Record<string, unknown>;
-}
+export type BlockTuneSerialized = Record<string, unknown>;

--- a/src/entities/EditorDocument/EditorDocument.spec.ts
+++ b/src/entities/EditorDocument/EditorDocument.spec.ts
@@ -231,10 +231,7 @@ describe('EditorDocument', () => {
   });
 
   describe('.getBlock()', () => {
-    /**
-     * @todo move this to integration tests
-     */
-    it.skip('should return the block from the specific index', () => {
+    it('should return the block from the specific index', () => {
       const countOfBlocks = 5;
       const blocksData = [];
       const document = new EditorDocument();
@@ -253,8 +250,8 @@ describe('EditorDocument', () => {
 
       const block = document.getBlock(index);
 
-      expect(block.serialized)
-        .toBe(blocksData[index]);
+      expect(block)
+        .toBeInstanceOf(BlockNode);
     });
 
     it('should throw an error if index is less then 0', () => {
@@ -584,11 +581,11 @@ describe('EditorDocument', () => {
     beforeEach(() => {
       const blockData = {
         name: 'header' as BlockToolName,
-        data: {}
+        data: {},
       };
 
       document = new EditorDocument({
-        blocks: [blockData],
+        blocks: [ blockData ],
       });
 
       block = document.getBlock(0);
@@ -628,11 +625,11 @@ describe('EditorDocument', () => {
     beforeEach(() => {
       const blockData = {
         name: 'header' as BlockToolName,
-        data: {}
+        data: {},
       };
 
       document = new EditorDocument({
-        blocks: [blockData],
+        blocks: [ blockData ],
       });
 
       block = document.getBlock(0);
@@ -686,11 +683,11 @@ describe('EditorDocument', () => {
     beforeEach(() => {
       const blockData = {
         name: 'header' as BlockToolName,
-        data: {}
+        data: {},
       };
 
       document = new EditorDocument({
-        blocks: [blockData],
+        blocks: [ blockData ],
       });
 
       block = document.getBlock(0);
@@ -733,11 +730,11 @@ describe('EditorDocument', () => {
     beforeEach(() => {
       const blockData = {
         name: 'header' as BlockToolName,
-        data: {}
+        data: {},
       };
 
       document = new EditorDocument({
-        blocks: [blockData],
+        blocks: [ blockData ],
       });
 
       block = document.getBlock(0);
@@ -755,6 +752,29 @@ describe('EditorDocument', () => {
     it('should throw an error if index is out of bounds', () => {
       expect(() => document.unformat(document.length + 1, dataKey, tool, start, end))
         .toThrowError('Index out of bounds');
+    });
+  });
+
+  describe('.serialized', () => {
+    it('should call .serialized property of the BlockNodes', () => {
+      const spy  = jest.spyOn(BlockNode.prototype, 'serialized', 'get');
+      const document = createEditorDocumentWithSomeBlocks();
+
+      document.serialized;
+
+      expect(spy).toBeCalledTimes(document.length);
+    });
+
+
+    it('should return document properties', () => {
+      const properties = {
+        readOnly: true,
+      };
+      const document = new EditorDocument({
+        properties,
+      });
+
+      expect(document.serialized).toHaveProperty('properties', properties);
     });
   });
 });

--- a/src/entities/EditorDocument/EditorDocument.spec.ts
+++ b/src/entities/EditorDocument/EditorDocument.spec.ts
@@ -1,6 +1,5 @@
 import { EditorDocument } from './index';
 import { BlockNode, BlockToolName, DataKey } from '../BlockNode';
-import { BlockNodeConstructorParameters } from '../BlockNode/types';
 import type { BlockTuneName } from '../BlockTune';
 import { InlineToolData, InlineToolName } from '../inline-fragments';
 
@@ -11,14 +10,16 @@ jest.mock('../BlockNode');
  */
 function createEditorDocumentWithSomeBlocks(): EditorDocument {
   const countOfBlocks = 3;
-  const blocks = new Array(countOfBlocks).fill(undefined)
-    .map(() => new BlockNode({
-      name: 'header' as BlockToolName,
-    }));
+  const document = new EditorDocument({});
 
-  return new EditorDocument({
-    children: blocks,
-  });
+  new Array(countOfBlocks).fill(undefined)
+    .forEach(() => {
+      document.addBlock({
+        name: 'header' as BlockToolName,
+      });
+    });
+
+  return document;
 }
 
 describe('EditorDocument', () => {
@@ -31,7 +32,6 @@ describe('EditorDocument', () => {
       // Arrange
       const blocksCount = 3;
       const document = new EditorDocument({
-        children: [],
         properties: {
           readOnly: false,
         },
@@ -49,7 +49,8 @@ describe('EditorDocument', () => {
       const actual = document.length;
 
       // Assert
-      expect(actual).toBe(blocksCount);
+      expect(actual)
+        .toBe(blocksCount);
     });
   });
 
@@ -66,8 +67,11 @@ describe('EditorDocument', () => {
       const lastBlock = document.getBlock(document.length - 1);
       const blockBeforeAdded = document.getBlock(document.length - 2);
 
-      expect(lastBlockBeforeTest).not.toBe(lastBlock);
-      expect(blockBeforeAdded).toBe(lastBlockBeforeTest);
+      expect(lastBlockBeforeTest)
+        .not
+        .toBe(lastBlock);
+      expect(blockBeforeAdded)
+        .toBe(lastBlockBeforeTest);
     });
 
     it('should add the block to the beginning of the document if index is 0', () => {
@@ -82,8 +86,11 @@ describe('EditorDocument', () => {
       const firstBlock = document.getBlock(0);
       const blockAfterAdded = document.getBlock(1);
 
-      expect(firstBlockBeforeTest).not.toBe(firstBlock);
-      expect(blockAfterAdded).toBe(firstBlockBeforeTest);
+      expect(firstBlockBeforeTest)
+        .not
+        .toBe(firstBlock);
+      expect(blockAfterAdded)
+        .toBe(firstBlockBeforeTest);
     });
 
     it('should add the block to the specified index in the middle of the document', () => {
@@ -99,8 +106,11 @@ describe('EditorDocument', () => {
       const addedBlock = document.getBlock(index);
       const blockAfterAdded = document.getBlock(index + 1);
 
-      expect(blockBeforeTest).not.toBe(addedBlock);
-      expect(blockBeforeTest).toBe(blockAfterAdded);
+      expect(blockBeforeTest)
+        .not
+        .toBe(addedBlock);
+      expect(blockBeforeTest)
+        .toBe(blockAfterAdded);
     });
 
     it('should add the block to the end of the document if the index after the last element is passed', () => {
@@ -115,8 +125,11 @@ describe('EditorDocument', () => {
       const lastBlock = document.getBlock(document.length - 1);
       const blockBeforeAdded = document.getBlock(document.length - 2);
 
-      expect(lastBlockBeforeTest).not.toBe(lastBlock);
-      expect(blockBeforeAdded).toBe(lastBlockBeforeTest);
+      expect(lastBlockBeforeTest)
+        .not
+        .toBe(lastBlock);
+      expect(blockBeforeAdded)
+        .toBe(lastBlockBeforeTest);
     });
 
     it('should throw an error if index is less then 0', () => {
@@ -130,7 +143,8 @@ describe('EditorDocument', () => {
       const action = (): void => document.addBlock(blockData, -1);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
 
     it('should throw an error if index is greater then document length', () => {
@@ -144,7 +158,8 @@ describe('EditorDocument', () => {
       const action = (): void => document.addBlock(blockData, document.length + 1);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -158,7 +173,9 @@ describe('EditorDocument', () => {
       document.removeBlock(0);
 
       // Assert
-      expect(document.getBlock(0)).not.toBe(block);
+      expect(document.getBlock(0))
+        .not
+        .toBe(block);
     });
 
     it('should remove the block from the specified index in the middle of the document', () => {
@@ -170,7 +187,9 @@ describe('EditorDocument', () => {
       document.removeBlock(1);
 
       // Assert
-      expect(document.getBlock(1)).not.toBe(block);
+      expect(document.getBlock(1))
+        .not
+        .toBe(block);
     });
 
     it('should remove the block from the end of the document if the last index is passed', () => {
@@ -182,7 +201,8 @@ describe('EditorDocument', () => {
       document.removeBlock(document.length - 1);
 
       // Assert
-      expect(document.length).toBe(documentLengthBeforeRemove - 1);
+      expect(document.length)
+        .toBe(documentLengthBeforeRemove - 1);
     });
 
     it('should throw an error if index is less then 0', () => {
@@ -193,7 +213,8 @@ describe('EditorDocument', () => {
       const action = (): void => document.removeBlock(-1);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
 
     it('should throw an error if index is greater then document length', () => {
@@ -204,32 +225,36 @@ describe('EditorDocument', () => {
       const action = (): void => document.removeBlock(document.length);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
   });
 
   describe('.getBlock()', () => {
-    it('should return the block from the specific index', () => {
+    /**
+     * @todo move this to integration tests
+     */
+    it.skip('should return the block from the specific index', () => {
       const countOfBlocks = 5;
-      const blocks = [];
+      const blocksData = [];
+      const document = new EditorDocument();
 
       for (let i = 0; i < countOfBlocks; i++) {
-        const block = new BlockNode({
+        const blockData = {
           name: (`header-${i}`) as BlockToolName,
-        });
+        };
 
-        blocks.push(block);
+        document.addBlock(blockData);
+
+        blocksData.push(blockData);
       }
-
-      const document = new EditorDocument({
-        children: blocks,
-      });
 
       const index = 1;
 
       const block = document.getBlock(index);
 
-      expect(block).toBe(blocks[index]);
+      expect(block.serialized)
+        .toBe(blocksData[index]);
     });
 
     it('should throw an error if index is less then 0', () => {
@@ -240,7 +265,8 @@ describe('EditorDocument', () => {
       const action = (): BlockNode => document.getBlock(-1);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
 
     it('should throw an error if index is greater then document length', () => {
@@ -251,14 +277,15 @@ describe('EditorDocument', () => {
       const action = (): BlockNode => document.getBlock(document.length);
 
       // Assert
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
   });
 
   describe('.properties', () => {
     it('should return the properties of the document', () => {
       const properties = {
-        'readOnly' : true,
+        'readOnly': true,
       };
 
       const document = new EditorDocument({
@@ -267,7 +294,8 @@ describe('EditorDocument', () => {
         },
       });
 
-      expect(document.properties).toEqual(properties);
+      expect(document.properties)
+        .toEqual(properties);
     });
   });
 
@@ -283,7 +311,8 @@ describe('EditorDocument', () => {
 
       const actualValue = document.getProperty<boolean>(propertyName);
 
-      expect(actualValue).toBe(expectedValue);
+      expect(actualValue)
+        .toBe(expectedValue);
     });
 
     it('should return undefined if the property does not exist', () => {
@@ -294,7 +323,8 @@ describe('EditorDocument', () => {
 
       const actualValue = document.getProperty<boolean>(propertyName);
 
-      expect(actualValue).toBeUndefined();
+      expect(actualValue)
+        .toBeUndefined();
     });
   });
 
@@ -310,7 +340,8 @@ describe('EditorDocument', () => {
 
       document.setProperty(propertyName, expectedValue);
 
-      expect(document.properties[propertyName]).toBe(expectedValue);
+      expect(document.properties[propertyName])
+        .toBe(expectedValue);
     });
 
     it('should add the property if it does not exist', () => {
@@ -322,7 +353,8 @@ describe('EditorDocument', () => {
 
       document.setProperty(propertyName, expectedValue);
 
-      expect(document.properties[propertyName]).toBe(expectedValue);
+      expect(document.properties[propertyName])
+        .toBe(expectedValue);
     });
   });
 
@@ -332,48 +364,75 @@ describe('EditorDocument', () => {
     });
 
     it('should call .updateValue() method of the BlockNode at the specific index', () => {
-      const blockNodes = [
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
+      const blocksData = [
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
       ];
+      const document = new EditorDocument({
+        blocks: blocksData,
+      });
 
-      blockNodes.forEach((blockNode) => {
+      blocksData.forEach((_, i) => {
+        const blockNode = document.getBlock(i);
+
         jest
           .spyOn(blockNode, 'updateValue')
           // eslint-disable-next-line @typescript-eslint/no-empty-function -- mock of the method
-          .mockImplementation(() => {});
+          .mockImplementation(() => {
+          });
       });
 
-      const document = new EditorDocument({
-        children: blockNodes,
-      });
       const blockIndexToUpdate = 1;
       const dataKey = 'data-key-1a2b' as DataKey;
       const value = 'Some value';
 
       document.updateValue(blockIndexToUpdate, dataKey, value);
 
-      expect(document.getBlock(blockIndexToUpdate).updateValue).toHaveBeenCalledWith(dataKey, value);
+      expect(document.getBlock(blockIndexToUpdate).updateValue)
+        .toHaveBeenCalledWith(dataKey, value);
     });
 
     it('should not call .updateValue() method of other BlockNodes', () => {
-      const blockNodes = [
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
+      const blocksData = [
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
       ];
+      const document = new EditorDocument({
+        blocks: blocksData,
+      });
 
-      blockNodes.forEach((blockNode) => {
+      const blockNodes = blocksData.map((_, i) => {
+        const blockNode = document.getBlock(i);
+
         jest
           .spyOn(blockNode, 'updateValue')
           // eslint-disable-next-line @typescript-eslint/no-empty-function -- mock of the method
-          .mockImplementation(() => {});
+          .mockImplementation(() => {
+          });
+
+        return blockNode;
       });
 
-      const document = new EditorDocument({
-        children: blockNodes,
-      });
       const blockIndexToUpdate = 1;
       const dataKey = 'data-key-1a2b' as DataKey;
       const value = 'Some value';
@@ -385,7 +444,9 @@ describe('EditorDocument', () => {
           return;
         }
 
-        expect(blockNode.updateValue).not.toHaveBeenCalled();
+        expect(blockNode.updateValue)
+          .not
+          .toHaveBeenCalled();
       });
     });
 
@@ -397,7 +458,8 @@ describe('EditorDocument', () => {
 
       const action = (): void => document.updateValue(blockIndexOutOfBound, dataKey, expectedValue);
 
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -407,22 +469,34 @@ describe('EditorDocument', () => {
     });
 
     it('should call .updateTuneData() method of the BlockNode at the specific index', () => {
-      const blockNodes = [
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
+      const blocksData = [
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
       ];
+      const document = new EditorDocument({
+        blocks: blocksData,
+      });
 
-      blockNodes.forEach((blockNode) => {
+      blocksData.forEach((_, i) => {
+        const blockNode = document.getBlock(i);
+
         jest
           .spyOn(blockNode, 'updateTuneData')
           // eslint-disable-next-line @typescript-eslint/no-empty-function -- mock of the method
-          .mockImplementation(() => {});
+          .mockImplementation(() => {
+          });
       });
 
-      const document = new EditorDocument({
-        children: blockNodes,
-      });
       const blockIndexToUpdate = 1;
       const tuneName = 'blockFormatting' as BlockTuneName;
       const updateData = {
@@ -431,26 +505,41 @@ describe('EditorDocument', () => {
 
       document.updateTuneData(blockIndexToUpdate, tuneName, updateData);
 
-      expect(document.getBlock(blockIndexToUpdate).updateTuneData).toHaveBeenCalledWith(tuneName, updateData);
+      expect(document.getBlock(blockIndexToUpdate).updateTuneData)
+        .toHaveBeenCalledWith(tuneName, updateData);
     });
 
     it('should not call .updateTuneData() method of other BlockNodes', () => {
-      const blockNodes = [
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
-        new BlockNode({} as BlockNodeConstructorParameters),
+      const blocksData = [
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
+        {
+          name: 'header' as BlockToolName,
+          data: {},
+        },
       ];
+      const document = new EditorDocument({
+        blocks: blocksData,
+      });
 
-      blockNodes.forEach((blockNode) => {
+      const blockNodes = blocksData.map((_, i) => {
+        const blockNode = document.getBlock(i);
+
         jest
           .spyOn(blockNode, 'updateTuneData')
           // eslint-disable-next-line @typescript-eslint/no-empty-function -- mock of the method
-          .mockImplementation(() => {});
+          .mockImplementation(() => {
+          });
+
+        return blockNode;
       });
 
-      const document = new EditorDocument({
-        children: blockNodes,
-      });
       const blockIndexToUpdate = 1;
       const tuneName = 'blockFormatting' as BlockTuneName;
       const updateData = {
@@ -464,7 +553,9 @@ describe('EditorDocument', () => {
           return;
         }
 
-        expect(blockNode.updateTuneData).not.toHaveBeenCalled();
+        expect(blockNode.updateTuneData)
+          .not
+          .toHaveBeenCalled();
       });
     });
 
@@ -478,7 +569,8 @@ describe('EditorDocument', () => {
 
       const action = (): void => document.updateTuneData(blockIndexOutOfBound, tuneName, updateData);
 
-      expect(action).toThrowError('Index out of bounds');
+      expect(action)
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -490,10 +582,16 @@ describe('EditorDocument', () => {
     let block: BlockNode;
 
     beforeEach(() => {
-      block = new BlockNode({} as BlockNodeConstructorParameters);
+      const blockData = {
+        name: 'header' as BlockToolName,
+        data: {}
+      };
+
       document = new EditorDocument({
-        children: [ block ],
+        blocks: [blockData],
       });
+
+      block = document.getBlock(0);
     });
 
     it('should call .insertText() method of the BlockNode', () => {
@@ -501,7 +599,8 @@ describe('EditorDocument', () => {
 
       document.insertText(blockIndex, dataKey, text);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, text, undefined);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, text, undefined);
     });
 
     it('should pass start index to the .insertText() method of the BlockNode', () => {
@@ -510,11 +609,13 @@ describe('EditorDocument', () => {
 
       document.insertText(blockIndex, dataKey, text, start);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, text, start);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, text, start);
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => document.insertText(document.length + 1, dataKey, text)).toThrowError('Index out of bounds');
+      expect(() => document.insertText(document.length + 1, dataKey, text))
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -525,10 +626,16 @@ describe('EditorDocument', () => {
     let block: BlockNode;
 
     beforeEach(() => {
-      block = new BlockNode({} as BlockNodeConstructorParameters);
+      const blockData = {
+        name: 'header' as BlockToolName,
+        data: {}
+      };
+
       document = new EditorDocument({
-        children: [ block ],
+        blocks: [blockData],
       });
+
+      block = document.getBlock(0);
     });
 
     it('should call .removeText() method of the BlockNode', () => {
@@ -536,7 +643,8 @@ describe('EditorDocument', () => {
 
       document.removeText(blockIndex, dataKey);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, undefined, undefined);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, undefined, undefined);
     });
 
     it('should pass start index to the .removeText() method of the BlockNode', () => {
@@ -545,7 +653,8 @@ describe('EditorDocument', () => {
 
       document.removeText(blockIndex, dataKey, start);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, start, undefined);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, start, undefined);
     });
 
     it('should pass end index to the .removeText() method of the BlockNode', () => {
@@ -555,11 +664,13 @@ describe('EditorDocument', () => {
 
       document.removeText(blockIndex, dataKey, start, end);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, start, end);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, start, end);
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => document.removeText(document.length + 1, dataKey)).toThrowError('Index out of bounds');
+      expect(() => document.removeText(document.length + 1, dataKey))
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -573,10 +684,16 @@ describe('EditorDocument', () => {
     let block: BlockNode;
 
     beforeEach(() => {
-      block = new BlockNode({} as BlockNodeConstructorParameters);
+      const blockData = {
+        name: 'header' as BlockToolName,
+        data: {}
+      };
+
       document = new EditorDocument({
-        children: [ block ],
+        blocks: [blockData],
       });
+
+      block = document.getBlock(0);
     });
 
     it('should call .format() method of the BlockNode', () => {
@@ -584,7 +701,8 @@ describe('EditorDocument', () => {
 
       document.format(blockIndex, dataKey, tool, start, end);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, tool, start, end, undefined);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, tool, start, end, undefined);
     });
 
     it('should pass data to the .format() method of the BlockNode', () => {
@@ -593,11 +711,13 @@ describe('EditorDocument', () => {
 
       document.format(blockIndex, dataKey, tool, start, end, data);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, tool, start, end, data);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, tool, start, end, data);
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => document.format(document.length + 1, dataKey, tool, start, end)).toThrowError('Index out of bounds');
+      expect(() => document.format(document.length + 1, dataKey, tool, start, end))
+        .toThrowError('Index out of bounds');
     });
   });
 
@@ -611,10 +731,16 @@ describe('EditorDocument', () => {
     let block: BlockNode;
 
     beforeEach(() => {
-      block = new BlockNode({} as BlockNodeConstructorParameters);
+      const blockData = {
+        name: 'header' as BlockToolName,
+        data: {}
+      };
+
       document = new EditorDocument({
-        children: [ block ],
+        blocks: [blockData],
       });
+
+      block = document.getBlock(0);
     });
 
     it('should call .unformat() method of the BlockNode', () => {
@@ -622,11 +748,13 @@ describe('EditorDocument', () => {
 
       document.unformat(blockIndex, dataKey, tool, start, end);
 
-      expect(spy).toHaveBeenCalledWith(dataKey, tool, start, end);
+      expect(spy)
+        .toHaveBeenCalledWith(dataKey, tool, start, end);
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => document.unformat(document.length + 1, dataKey, tool, start, end)).toThrowError('Index out of bounds');
+      expect(() => document.unformat(document.length + 1, dataKey, tool, start, end))
+        .toThrowError('Index out of bounds');
     });
   });
 });

--- a/src/entities/EditorDocument/index.ts
+++ b/src/entities/EditorDocument/index.ts
@@ -222,8 +222,9 @@ export class EditorDocument {
   }
 
   /**
+   * Initializes EditorDocument with passed blocks
    *
-   * @param blocks
+   * @param blocks - document serialized blocks
    */
   #initialize(blocks: BlockNodeSerialized[]): void {
     blocks.forEach((block) => {

--- a/src/entities/EditorDocument/index.ts
+++ b/src/entities/EditorDocument/index.ts
@@ -1,9 +1,10 @@
 import { BlockNode, DataKey } from '../BlockNode';
-import type { BlockNodeData, EditorDocumentConstructorParameters, Properties } from './types';
+import type { EditorDocumentSerialized, EditorDocumentConstructorParameters, Properties } from './types';
 import { BlockTuneName } from '../BlockTune';
 import { InlineToolData, InlineToolName } from '../inline-fragments';
 import { IoCContainer, TOOLS_REGISTRY } from '../../IoC';
 import { ToolsRegistry } from '../../tools';
+import { BlockNodeSerialized } from '../BlockNode/types';
 
 /**
  * EditorDocument class represents the top-level container for a tree-like structure of BlockNodes in an editor document.
@@ -13,7 +14,7 @@ export class EditorDocument {
   /**
    * Private field representing the child BlockNodes of the EditorDocument
    */
-  #children: BlockNode[];
+  #children: BlockNode[] = [];
 
   /**
    * Private field representing the properties of the document
@@ -28,13 +29,14 @@ export class EditorDocument {
    * @param [args.properties] - The properties of the document.
    * @param [args.toolsRegistry] - ToolsRegistry instance for the current document. Defaults to a new ToolsRegistry instance.
    */
-  constructor({ children = [], properties = {}, toolsRegistry = new ToolsRegistry() }: EditorDocumentConstructorParameters = {}) {
-    this.#children = children;
+  constructor({ blocks = [], properties = {}, toolsRegistry = new ToolsRegistry() }: EditorDocumentConstructorParameters = {}) {
     this.#properties = properties;
 
     const container = IoCContainer.of(this);
 
     container.set(TOOLS_REGISTRY, toolsRegistry);
+
+    this.#initialize(blocks);
   }
 
   /**
@@ -52,7 +54,7 @@ export class EditorDocument {
    * @param index - The index at which to add the BlockNode
    * @throws Error if the index is out of bounds
    */
-  public addBlock(blockNodeData: BlockNodeData, index?: number): void {
+  public addBlock(blockNodeData: BlockNodeSerialized, index?: number): void {
     const blockNode = new BlockNode({
       ...blockNodeData,
       parent: this,
@@ -207,6 +209,26 @@ export class EditorDocument {
     this.#checkIndexOutOfBounds(blockIndex, this.length - 1);
 
     this.#children[blockIndex].unformat(key, tool, start, end);
+  }
+
+  /**
+   *
+   */
+  public get serialized(): EditorDocumentSerialized {
+    return {
+      blocks: this.#children.map((block) => block.serialized),
+      properties: this.#properties,
+    };
+  }
+
+  /**
+   *
+   * @param blocks
+   */
+  #initialize(blocks: BlockNodeSerialized[]): void {
+    blocks.forEach((block) => {
+      this.addBlock(block);
+    });
   }
 
   /**

--- a/src/entities/EditorDocument/index.ts
+++ b/src/entities/EditorDocument/index.ts
@@ -212,7 +212,11 @@ export class EditorDocument {
   }
 
   /**
+   * Returns serialized data associated with the document
    *
+   * Data contains:
+   * - blocks - array of serialized blocks
+   * - properties - JSON object with document properties (eg read-only)
    */
   public get serialized(): EditorDocumentSerialized {
     return {

--- a/src/entities/EditorDocument/index.ts
+++ b/src/entities/EditorDocument/index.ts
@@ -54,7 +54,7 @@ export class EditorDocument {
    * @param index - The index at which to add the BlockNode
    * @throws Error if the index is out of bounds
    */
-  public addBlock(blockNodeData: BlockNodeSerialized, index?: number): void {
+  public addBlock(blockNodeData: Pick<BlockNodeSerialized, 'name'> & Partial<Omit<BlockNodeSerialized, 'name'>>, index?: number): void {
     const blockNode = new BlockNode({
       ...blockNodeData,
       parent: this,

--- a/src/entities/EditorDocument/types/EditorDocumentConstructorParameters.ts
+++ b/src/entities/EditorDocument/types/EditorDocumentConstructorParameters.ts
@@ -1,12 +1,12 @@
-import type { BlockNode } from '../../BlockNode';
 import type { Properties } from './Properties';
 import { ToolsRegistry } from '../../../tools/ToolsRegistry';
+import { BlockNodeSerialized } from '../../BlockNode/types';
 
 export interface EditorDocumentConstructorParameters {
   /**
    * The child BlockNodes of the EditorDocument
    */
-  children?: BlockNode[];
+  blocks?: BlockNodeSerialized[];
 
   /**
    * The properties of the document

--- a/src/entities/EditorDocument/types/EditorDocumentSerialized.ts
+++ b/src/entities/EditorDocument/types/EditorDocumentSerialized.ts
@@ -1,7 +1,19 @@
 import { BlockNodeSerialized } from '../../BlockNode/types';
 import { Properties } from './Properties';
 
+/**
+ * Type representing serialized EditorDocument
+ *
+ * Serialized EditorDocument is a JSON object containing blocks and document properties
+ */
 export interface EditorDocumentSerialized {
-    blocks: BlockNodeSerialized[];
-    properties: Properties;
+  /**
+   * Array of serialized BlockNodes
+   */
+  blocks: BlockNodeSerialized[];
+
+  /**
+   * JSON object containing document properties (eg read-only)
+   */
+  properties: Properties;
 }

--- a/src/entities/EditorDocument/types/EditorDocumentSerialized.ts
+++ b/src/entities/EditorDocument/types/EditorDocumentSerialized.ts
@@ -1,0 +1,7 @@
+import { BlockNodeSerialized } from '../../BlockNode/types';
+import { Properties } from './Properties';
+
+export interface EditorDocumentSerialized {
+    blocks: BlockNodeSerialized[];
+    properties: Properties;
+}

--- a/src/entities/EditorDocument/types/index.ts
+++ b/src/entities/EditorDocument/types/index.ts
@@ -1,3 +1,4 @@
 export type { EditorDocumentConstructorParameters } from './EditorDocumentConstructorParameters';
 export type { Properties } from './Properties';
 export type { BlockNodeData } from './BlockNodeData';
+export type { EditorDocumentSerialized } from './EditorDocumentSerialized';

--- a/src/entities/ValueNode/ValueNode.spec.ts
+++ b/src/entities/ValueNode/ValueNode.spec.ts
@@ -1,4 +1,5 @@
 import { ValueNode } from './index';
+import { BlockChildType } from '../BlockNode/types';
 
 describe('ValueNode', () => {
   describe('.update()', () => {
@@ -30,6 +31,17 @@ describe('ValueNode', () => {
 
       // Assert
       expect(serializedLongitude).toStrictEqual(longitude);
+    });
+
+    it('should mark serialized value as value node if object returned', () => {
+      const value = { align: 'left' };
+      const longitudeValueNode = new ValueNode({
+        value,
+      });
+
+      const serializedValue = longitudeValueNode.serialized;
+
+      expect(serializedValue).toHaveProperty('$t', BlockChildType.Value);
     });
   });
 });

--- a/src/entities/ValueNode/ValueNode.spec.ts
+++ b/src/entities/ValueNode/ValueNode.spec.ts
@@ -1,5 +1,6 @@
 import { ValueNode } from './index';
 import { BlockChildType } from '../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../BlockNode/consts';
 
 describe('ValueNode', () => {
   describe('.update()', () => {
@@ -33,7 +34,7 @@ describe('ValueNode', () => {
       expect(serializedLongitude).toStrictEqual(longitude);
     });
 
-    it('should mark serialized value as value node if object returned', () => {
+    it('should mark serialized value as value node by using custom hidden property $t  if object returned', () => {
       const value = { align: 'left' };
       const longitudeValueNode = new ValueNode({
         value,
@@ -41,7 +42,7 @@ describe('ValueNode', () => {
 
       const serializedValue = longitudeValueNode.serialized;
 
-      expect(serializedValue).toHaveProperty('$t', BlockChildType.Value);
+      expect(serializedValue).toHaveProperty(NODE_TYPE_HIDDEN_PROP, BlockChildType.Value);
     });
   });
 });

--- a/src/entities/ValueNode/index.ts
+++ b/src/entities/ValueNode/index.ts
@@ -1,4 +1,5 @@
-import type { ValueNodeConstructorParameters } from './types';
+import type { ValueNodeConstructorParameters, ValueSerialized } from './types';
+import { BlockChildType } from '../BlockNode/types';
 
 /**
  * ValueNode class represents a node in a tree-like structure, used to store and manipulate data associated with a BlockNode.
@@ -33,8 +34,14 @@ export class ValueNode<ValueType = unknown> {
   /**
    * Returns serialized data associated with this value node.
    */
-  public get serialized(): ValueType {
-    return this.#value;
+  public get serialized(): ValueSerialized<ValueType> {
+    let value = this.#value;
+
+    if (typeof value === 'object' && this.#value !== null) {
+      value = Object.assign({ $t: BlockChildType.Value }, value);
+    }
+
+    return value as ValueSerialized<ValueType>;
   }
 }
 

--- a/src/entities/ValueNode/index.ts
+++ b/src/entities/ValueNode/index.ts
@@ -1,5 +1,6 @@
 import type { ValueNodeConstructorParameters, ValueSerialized } from './types';
 import { BlockChildType } from '../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../BlockNode/consts';
 
 /**
  * ValueNode class represents a node in a tree-like structure, used to store and manipulate data associated with a BlockNode.
@@ -38,7 +39,7 @@ export class ValueNode<ValueType = unknown> {
     let value = this.#value;
 
     if (typeof value === 'object' && this.#value !== null) {
-      value = Object.assign({ $t: BlockChildType.Value }, value);
+      value = Object.assign({ [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Value }, value);
     }
 
     return value as ValueSerialized<ValueType>;

--- a/src/entities/ValueNode/types/ValueSerialized.ts
+++ b/src/entities/ValueNode/types/ValueSerialized.ts
@@ -1,6 +1,9 @@
 import { BlockChildType } from '../../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../../BlockNode/consts';
 
 /**
  * Type representing serialized ValueNode
+ *
+ * Serialized ValueNode is a JSON primitive value or a JSON object with hidden property $t
  */
-export type ValueSerialized<V = unknown> = V extends Record<string | number | symbol, unknown> ? V & { $t: BlockChildType.Value } : V;
+export type ValueSerialized<V = unknown> = V extends Record<string | number | symbol, unknown> ? V & { [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Value } : V;

--- a/src/entities/ValueNode/types/ValueSerialized.ts
+++ b/src/entities/ValueNode/types/ValueSerialized.ts
@@ -1,3 +1,6 @@
 import { BlockChildType } from '../../BlockNode/types';
 
-export type ValueSerialized<V = unknown> = V extends Record<any, any> ? V & { $t: BlockChildType.Value } : V;
+/**
+ * Type representing serialized ValueNode
+ */
+export type ValueSerialized<V = unknown> = V extends Record<string | number | symbol, unknown> ? V & { $t: BlockChildType.Value } : V;

--- a/src/entities/ValueNode/types/ValueSerialized.ts
+++ b/src/entities/ValueNode/types/ValueSerialized.ts
@@ -1,0 +1,3 @@
+import { BlockChildType } from '../../BlockNode/types';
+
+export type ValueSerialized<V = unknown> = V extends Record<any, any> ? V & { $t: BlockChildType.Value } : V;

--- a/src/entities/ValueNode/types/index.ts
+++ b/src/entities/ValueNode/types/index.ts
@@ -1,1 +1,2 @@
 export { ValueNodeConstructorParameters } from './ValueNodeConstructorParameters';
+export { ValueSerialized } from './ValueSerialized';

--- a/src/entities/inline-fragments/InlineNode/index.ts
+++ b/src/entities/inline-fragments/InlineNode/index.ts
@@ -1,4 +1,5 @@
 import { InlineToolData, InlineToolName } from '../FormattingInlineNode';
+import { BlockChildType } from '../../BlockNode/types';
 
 /**
  * Interface describing abstract InlineNode — common properties and methods for all inline nodes
@@ -12,7 +13,7 @@ export interface InlineNode {
   /**
    * Serialized value of the node
    */
-  readonly serialized: TextNodeSerialized;
+  readonly serialized: ChildTextNodeSerialized;
 
   /**
    * Returns text value in passed range
@@ -122,7 +123,7 @@ export interface InlineFragment {
 /**
  * Serialized Inline Node value
  */
-export interface TextNodeSerialized {
+export interface ChildTextNodeSerialized {
   /**
    * Text value of the node and its subtree
    */
@@ -132,4 +133,8 @@ export interface TextNodeSerialized {
    * Fragments which node and its subtree contains
    */
   fragments: InlineFragment[];
+}
+
+export interface TextNodeSerialized extends ChildTextNodeSerialized {
+  $t: BlockChildType.Text;
 }

--- a/src/entities/inline-fragments/InlineNode/index.ts
+++ b/src/entities/inline-fragments/InlineNode/index.ts
@@ -1,5 +1,6 @@
 import { InlineToolData, InlineToolName } from '../FormattingInlineNode';
 import { BlockChildType } from '../../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../../BlockNode/consts';
 
 /**
  * Interface describing abstract InlineNode — common properties and methods for all inline nodes
@@ -13,7 +14,7 @@ export interface InlineNode {
   /**
    * Serialized value of the node
    */
-  readonly serialized: ChildTextNodeSerialized;
+  readonly serialized: InlineTreeNodeSerialized;
 
   /**
    * Returns text value in passed range
@@ -122,12 +123,14 @@ export interface InlineFragment {
 
 /**
  * Serialized Inline Node value
+ *
+ * Interface used for tree nodes except TextNode which is a tree root
  */
-export interface ChildTextNodeSerialized {
+export interface InlineTreeNodeSerialized {
   /**
    * Text value of the node and its subtree
    */
-  text: string;
+  value: string;
 
   /**
    * Fragments which node and its subtree contains
@@ -137,7 +140,9 @@ export interface ChildTextNodeSerialized {
 
 /**
  * Root type representing serialized TextNode data
+ *
+ * Interface used for a tree root
  */
-export interface TextNodeSerialized extends ChildTextNodeSerialized {
-  $t: BlockChildType.Text;
+export interface TextNodeSerialized extends InlineTreeNodeSerialized {
+  [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text;
 }

--- a/src/entities/inline-fragments/InlineNode/index.ts
+++ b/src/entities/inline-fragments/InlineNode/index.ts
@@ -135,6 +135,9 @@ export interface ChildTextNodeSerialized {
   fragments: InlineFragment[];
 }
 
+/**
+ * Root type representing serialized TextNode data
+ */
 export interface TextNodeSerialized extends ChildTextNodeSerialized {
   $t: BlockChildType.Text;
 }

--- a/src/entities/inline-fragments/ParentInlineNode/index.ts
+++ b/src/entities/inline-fragments/ParentInlineNode/index.ts
@@ -1,4 +1,4 @@
-import { InlineFragment, InlineNode, ChildTextNodeSerialized } from '../InlineNode';
+import { InlineFragment, InlineNode, InlineTreeNodeSerialized } from '../InlineNode';
 import { ParentNode, ParentNodeConstructorOptions } from '../mixins/ParentNode';
 import { ChildNode } from '../mixins/ChildNode';
 import type { InlineToolData, InlineToolName } from '../FormattingInlineNode';
@@ -30,9 +30,9 @@ export class ParentInlineNode implements InlineNode {
   /**
    * Returns serialized value of the node: text and formatting fragments
    */
-  public get serialized(): ChildTextNodeSerialized {
+  public get serialized(): InlineTreeNodeSerialized {
     return {
-      text: this.getText(),
+      value: this.getText(),
       fragments: this.getFragments(),
     };
   }

--- a/src/entities/inline-fragments/ParentInlineNode/index.ts
+++ b/src/entities/inline-fragments/ParentInlineNode/index.ts
@@ -1,4 +1,4 @@
-import { InlineFragment, InlineNode, TextNodeSerialized } from '../InlineNode';
+import { InlineFragment, InlineNode, ChildTextNodeSerialized } from '../InlineNode';
 import { ParentNode, ParentNodeConstructorOptions } from '../mixins/ParentNode';
 import { ChildNode } from '../mixins/ChildNode';
 import type { InlineToolData, InlineToolName } from '../FormattingInlineNode';
@@ -30,7 +30,7 @@ export class ParentInlineNode implements InlineNode {
   /**
    * Returns serialized value of the node: text and formatting fragments
    */
-  public get serialized(): TextNodeSerialized {
+  public get serialized(): ChildTextNodeSerialized {
     return {
       text: this.getText(),
       fragments: this.getFragments(),

--- a/src/entities/inline-fragments/TextInlineNode/index.ts
+++ b/src/entities/inline-fragments/TextInlineNode/index.ts
@@ -1,6 +1,6 @@
 import { FormattingInlineNode, InlineToolName, InlineToolData } from '../index';
 import { TextInlineNodeConstructorParameters } from './types';
-import { InlineNode, ChildTextNodeSerialized } from '../InlineNode';
+import { InlineNode, InlineTreeNodeSerialized } from '../InlineNode';
 import { ChildNode } from '../mixins/ChildNode';
 
 export * from './types';
@@ -37,9 +37,9 @@ export class TextInlineNode implements InlineNode {
   /**
    * Returns serialized value of the node
    */
-  public get serialized(): ChildTextNodeSerialized {
+  public get serialized(): InlineTreeNodeSerialized {
     return {
-      text: this.getText(),
+      value: this.getText(),
       // No fragments for text node
       fragments: [],
     };

--- a/src/entities/inline-fragments/TextInlineNode/index.ts
+++ b/src/entities/inline-fragments/TextInlineNode/index.ts
@@ -1,6 +1,6 @@
 import { FormattingInlineNode, InlineToolName, InlineToolData } from '../index';
 import { TextInlineNodeConstructorParameters } from './types';
-import { InlineNode, TextNodeSerialized } from '../InlineNode';
+import { InlineNode, ChildTextNodeSerialized } from '../InlineNode';
 import { ChildNode } from '../mixins/ChildNode';
 
 export * from './types';
@@ -37,7 +37,7 @@ export class TextInlineNode implements InlineNode {
   /**
    * Returns serialized value of the node
    */
-  public get serialized(): TextNodeSerialized {
+  public get serialized(): ChildTextNodeSerialized {
     return {
       text: this.getText(),
       // No fragments for text node

--- a/src/entities/inline-fragments/TextNode/index.ts
+++ b/src/entities/inline-fragments/TextNode/index.ts
@@ -1,4 +1,5 @@
-import { InlineFragment, ParentInlineNode, ParentInlineNodeConstructorOptions } from '../index';
+import { InlineFragment, ParentInlineNode, ParentInlineNodeConstructorOptions, TextNodeSerialized } from '../index';
+import { BlockChildType } from '../../BlockNode/types';
 
 interface TextNodeConstructorOptions extends ParentInlineNodeConstructorOptions {
   value?: string;
@@ -21,6 +22,13 @@ export class TextNode extends ParentInlineNode {
     super(rest);
 
     this.#initialize(value, fragments);
+  }
+
+  /**
+   * Returns serialized TextNode
+   */
+  public get serialized(): TextNodeSerialized {
+    return Object.assign({ $t: BlockChildType.Text as const }, super.serialized);
   }
 
   /**

--- a/src/entities/inline-fragments/TextNode/index.ts
+++ b/src/entities/inline-fragments/TextNode/index.ts
@@ -1,5 +1,6 @@
 import { InlineFragment, ParentInlineNode, ParentInlineNodeConstructorOptions, TextNodeSerialized } from '../index';
 import { BlockChildType } from '../../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../../BlockNode/consts';
 
 interface TextNodeConstructorOptions extends ParentInlineNodeConstructorOptions {
   value?: string;
@@ -28,7 +29,7 @@ export class TextNode extends ParentInlineNode {
    * Returns serialized TextNode
    */
   public get serialized(): TextNodeSerialized {
-    return Object.assign({ $t: BlockChildType.Text as const }, super.serialized);
+    return Object.assign({ [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text as const }, super.serialized);
   }
 
   /**

--- a/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
+++ b/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { TextInlineNode, TextNode, createInlineToolData, createInlineToolName, ChildTextNodeSerialized } from '../index';
+import {
+  TextInlineNode,
+  TextNode,
+  createInlineToolData,
+  createInlineToolName,
+  TextNodeSerialized
+} from '../index';
+import { BlockChildType } from '../../BlockNode/types';
 
 describe('Inline fragments tree integration', () => {
   describe('text insertion', () => {
@@ -366,6 +373,7 @@ describe('Inline fragments tree integration', () => {
     tree.unformat(boldTool, ...(pluggable.map((value) => value - removedChars) as [number, number]));
 
     expect(tree.serialized).toStrictEqual({
+      $t: BlockChildType.Text,
       text: firstFragment + secondFragment.replace(' data', '') + thirdFragment,
       fragments: [
         {
@@ -390,6 +398,7 @@ describe('Inline fragments tree integration', () => {
 
   it('should initialize tree with initial text and fragments', () => {
     const data = {
+      $t: BlockChildType.Text,
       text: 'Editor.js is a block-styled editor. It returns clean output in JSON. Designed to be extendable and pluggable with a simple API.',
       fragments: [
         {
@@ -421,7 +430,7 @@ describe('Inline fragments tree integration', () => {
           ],
         },
       ],
-    } as ChildTextNodeSerialized;
+    } as TextNodeSerialized;
 
     const tree = new TextNode({
       value: data.text,

--- a/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
+++ b/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
@@ -7,6 +7,7 @@ import {
   TextNodeSerialized
 } from '../index';
 import { BlockChildType } from '../../BlockNode/types';
+import { NODE_TYPE_HIDDEN_PROP } from '../../BlockNode/consts';
 
 describe('Inline fragments tree integration', () => {
   describe('text insertion', () => {
@@ -373,8 +374,8 @@ describe('Inline fragments tree integration', () => {
     tree.unformat(boldTool, ...(pluggable.map((value) => value - removedChars) as [number, number]));
 
     expect(tree.serialized).toStrictEqual({
-      $t: BlockChildType.Text,
-      text: firstFragment + secondFragment.replace(' data', '') + thirdFragment,
+      [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+      value: firstFragment + secondFragment.replace(' data', '') + thirdFragment,
       fragments: [
         {
           tool: boldTool,
@@ -398,8 +399,8 @@ describe('Inline fragments tree integration', () => {
 
   it('should initialize tree with initial text and fragments', () => {
     const data = {
-      $t: BlockChildType.Text,
-      text: 'Editor.js is a block-styled editor. It returns clean output in JSON. Designed to be extendable and pluggable with a simple API.',
+      [NODE_TYPE_HIDDEN_PROP]: BlockChildType.Text,
+      value: 'Editor.js is a block-styled editor. It returns clean output in JSON. Designed to be extendable and pluggable with a simple API.',
       fragments: [
         {
           tool: 'bold',
@@ -433,7 +434,7 @@ describe('Inline fragments tree integration', () => {
     } as TextNodeSerialized;
 
     const tree = new TextNode({
-      value: data.text,
+      value: data.value,
       fragments: data.fragments,
     });
 

--- a/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
+++ b/src/entities/inline-fragments/specs/InlineTree.integration.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { TextInlineNode, TextNode, createInlineToolData, createInlineToolName, TextNodeSerialized } from '../index';
+import { TextInlineNode, TextNode, createInlineToolData, createInlineToolName, ChildTextNodeSerialized } from '../index';
 
 describe('Inline fragments tree integration', () => {
   describe('text insertion', () => {
@@ -421,7 +421,7 @@ describe('Inline fragments tree integration', () => {
           ],
         },
       ],
-    } as TextNodeSerialized;
+    } as ChildTextNodeSerialized;
 
     const tree = new TextNode({
       value: data.text,

--- a/src/entities/inline-fragments/specs/ParentInlineNode.spec.ts
+++ b/src/entities/inline-fragments/specs/ParentInlineNode.spec.ts
@@ -59,7 +59,7 @@ describe('ParentInlineNode', () => {
     it('should have correct data format', () => {
       const result = node.serialized;
 
-      expect(result).toHaveProperty('text');
+      expect(result).toHaveProperty('value');
       expect(result).toHaveProperty('fragments');
     });
   });

--- a/src/entities/inline-fragments/specs/TextInlineNode.spec.ts
+++ b/src/entities/inline-fragments/specs/TextInlineNode.spec.ts
@@ -264,7 +264,7 @@ describe('TextInlineNode', () => {
       const result = node.serialized;
 
       expect(result).toEqual({
-        text: initialText,
+        value: initialText,
         fragments: [],
       });
     });

--- a/src/tools/ToolsRegistry.ts
+++ b/src/tools/ToolsRegistry.ts
@@ -1,7 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import { BlockToolName, InlineToolName } from '../entities';
-import { BlockToolConstructable } from './types/BlockToolConstructable';
-import { InlineToolConstructable } from './types/InlineToolConstructable';
+import { BlockToolConstructable, InlineToolConstructable } from './types';
 
 /**
  * ToolsRegistry map stores Editor.js Tools by their names

--- a/src/tools/types/BlockDataType.ts
+++ b/src/tools/types/BlockDataType.ts
@@ -1,7 +1,0 @@
-/**
- * Possible types of BlockData values
- */
-export enum BlockDataType {
-  Value = '$value',
-  Text = '$text',
-}

--- a/src/tools/types/BlockToolConstructable.ts
+++ b/src/tools/types/BlockToolConstructable.ts
@@ -1,11 +1,4 @@
-import { BlockToolDataScheme } from './BlockToolDataScheme';
-
 /**
  * Interface describes BlockTool static properties
  */
-export interface BlockToolConstructable {
-  /**
-   * BlockTool data scheme to describe the structure of the data
-   */
-  scheme: BlockToolDataScheme;
-}
+export interface BlockToolConstructable {}

--- a/src/tools/types/BlockToolDataScheme.ts
+++ b/src/tools/types/BlockToolDataScheme.ts
@@ -1,9 +1,0 @@
-import { BlockDataType } from './BlockDataType';
-import { DataKey } from '../../entities';
-
-/**
- * Block Tool data scheme to describe the structure of the data
- */
-export interface BlockToolDataScheme {
-  [key: DataKey]: BlockDataType | BlockToolDataScheme | BlockDataType[] | BlockToolDataScheme[];
-}

--- a/src/tools/types/index.ts
+++ b/src/tools/types/index.ts
@@ -1,4 +1,2 @@
 export * from './BlockToolConstructable';
 export * from './InlineToolConstructable';
-export * from './BlockDataType';
-export * from './BlockToolDataScheme';

--- a/src/utils/keypath.spec.ts
+++ b/src/utils/keypath.spec.ts
@@ -1,0 +1,244 @@
+import { get, has, set } from './keypath';
+
+describe('keypath util', () => {
+  const value = 'value';
+
+  describe('set()', () => {
+    it('should do nothing if no key passed', () => {
+      const object = {};
+
+      set(object, [], value);
+
+      expect(object).toEqual(object);
+    });
+
+    it('should created nested objects by string key parts', () => {
+      const object: Record<string, any> = {};
+
+      set(object, 'a.b.c', value);
+
+      expect(object.a.b.c).toEqual(value);
+    });
+
+    it('should created nested objects by string key parts when keys passed as an array', () => {
+      const object: Record<string, any> = {};
+
+      set(object, ['a', 'b', 'c'], value);
+
+      expect(object.a.b.c).toEqual(value);
+    });
+
+    it('should update existing value', () => {
+      const updatedValue = 'updated value';
+      const object = {
+        value,
+      };
+
+      set(object, 'value', updatedValue);
+
+      expect(object.value).toEqual(updatedValue);
+    });
+
+    it('should update existing nested value', () => {
+      const updatedValue = 'updated value';
+      const object = {
+        a: { value },
+      };
+
+      set(object, 'a.value', updatedValue);
+
+      expect(object.a.value).toEqual(updatedValue);
+    });
+
+    it('should not replace a nested object', () => {
+      const updatedValue = 'updated value';
+      const object = {
+        a: {
+          value,
+          assert: 'assert',
+        },
+      };
+
+      set(object, 'a.value', updatedValue);
+
+      expect(object.a).toEqual({ assert: 'assert',
+        value: updatedValue });
+    });
+
+    it('should create array for numeric key parts', () => {
+      const object: Record<string, any> = {};
+
+      set(object, 'a.0', value);
+
+      expect(object.a).toBeInstanceOf(Array);
+    });
+
+    it('should insert value into array for numeric key parts', () => {
+      const object: Record<string, any> = {};
+
+      set(object, 'a.0', value);
+
+      expect(object.a[0]).toEqual(value);
+    });
+
+    it('should insert value into an array by the correct index for numeric key parts when index is ', () => {
+      const object: Record<string, any> = {};
+
+      set(object, 'a.1', value);
+
+      expect(object.a).toEqual([undefined, value]);
+    });
+
+    it('should create an object inside an array', () => {
+      const object: Record<string, any> = {};
+
+      set(object, 'a.0.b', value);
+
+      expect(object.a[0].b).toEqual(value);
+    });
+  });
+
+  describe('get()', () => {
+    it('should return original object if no key is passed', () => {
+      const object = {};
+
+      const result = get(object, []);
+
+      expect(result).toEqual(object);
+    });
+
+    it('should return value from nested objects', () => {
+      const object = {
+        a: {
+          b: {
+            c: value,
+          },
+        },
+      };
+
+      const result = get(object, 'a.b.c');
+
+      expect(result).toEqual(value);
+    });
+
+    it('should return a nested object if keypath is not full', () => {
+      const object = {
+        a: {
+          b: {
+            c: value,
+          },
+        },
+      };
+
+      const result = get(object, 'a.b');
+
+      expect(result).toEqual({ c: value });
+    });
+
+    it('should return value from nested objects when keys are passed as array', () => {
+      const object = {
+        a: {
+          b: {
+            c: value,
+          },
+        },
+      };
+
+      const result = get(object, ['a', 'b', 'c']);
+
+      expect(result).toEqual(value);
+    });
+
+    it('should return value from an array', () => {
+      const object = {
+        a: [ value ],
+      };
+
+      const result = get(object, 'a.0');
+
+      expect(result).toEqual(value);
+    });
+
+    it('should return value from an object inside an array', () => {
+      const object = {
+        a: [ { b: value } ],
+      };
+
+      const result = get(object, 'a.0.b');
+
+      expect(result).toEqual(value);
+    });
+
+    it('should return undefined if there is no value by given key', () => {
+      const object = {};
+
+      const result = get(object, 'a.b.c');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('has()', () => {
+    it('should return true if value exists by keypath', () => {
+      const object = {
+        a: {
+          b: {
+            c: value,
+          },
+        },
+      };
+
+      const result = has(object, 'a.b.c');
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if value doesnt exist by keypath', () => {
+      const object = {};
+
+      const result = has(object, 'a.b.c');
+
+      expect(result).toEqual(false);
+    });
+
+    it('should return true if value exists but equals false', () => {
+      const object = {
+        a: false,
+      };
+
+      const result = has(object, 'a');
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if value exists but equals 0', () => {
+      const object = {
+        a: 0,
+      };
+
+      const result = has(object, 'a');
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if value exists but equals null', () => {
+      const object = {
+        a: null,
+      };
+
+      const result = has(object, 'a');
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if value exists but equals empty string', () => {
+      const object = {
+        a: '',
+      };
+
+      const result = has(object, 'a');
+
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/src/utils/keypath.spec.ts
+++ b/src/utils/keypath.spec.ts
@@ -82,7 +82,7 @@ describe('keypath util', () => {
       expect(object.a[0]).toEqual(value);
     });
 
-    it('should insert value into an array by the correct index for numeric key parts when index is ', () => {
+    it('should insert value into an array by the correct index for numeric key parts when index is greater than array length', () => {
       const object: Record<string, any> = {};
 
       set(object, 'a.1', value);

--- a/src/utils/keypath.spec.ts
+++ b/src/utils/keypath.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { get, has, set } from './keypath';
 
 describe('keypath util', () => {

--- a/src/utils/keypath.ts
+++ b/src/utils/keypath.ts
@@ -1,0 +1,58 @@
+/**
+ * Get value from object by keypath
+ *
+ * @param data - object to get value from
+ * @param keys - keypath to a value
+ */
+export function get<T = unknown>(data: Record<any, any>, keys: string | string[]): T | undefined {
+  const parsedKeys  = Array.isArray(keys) ? keys : keys.split('.');
+  const key = parsedKeys.shift();
+
+  if (!key) {
+    return data as T;
+  }
+
+  if (data[key] === undefined) {
+    return undefined;
+  }
+
+  return get(data[key] as Record<string, unknown>, parsedKeys);
+}
+
+/**
+ * Set value to object by keypath
+ *
+ * @param data - object to set value to
+ * @param keys - keypath to a value
+ * @param value - value to set
+ */
+export function set<T = unknown>(data: Record<string, unknown>, keys: string | string[], value: T): void {
+  const parsedKeys  = Array.isArray(keys) ? keys : keys.split('.');
+  const key = parsedKeys.shift();
+
+  if (!key) {
+    return;
+  }
+
+  if (parsedKeys.length === 0) {
+    data[key] = value;
+
+    return;
+  }
+
+  if (data[key] === undefined) {
+    data[key] = !isNaN(Number(parsedKeys[0])) ? [] : {};
+  }
+
+  set(data[key] as Record<string, unknown>, parsedKeys, value);
+}
+
+/**
+ * Check if object has value by keypath
+ *
+ * @param data - object to check
+ * @param keys - keypath to a value
+ */
+export function has(data: Record<any, any>, keys: string | string[]): boolean {
+  return get(data, keys) !== undefined;
+}

--- a/src/utils/keypath.ts
+++ b/src/utils/keypath.ts
@@ -4,7 +4,7 @@
  * @param data - object to get value from
  * @param keys - keypath to a value
  */
-export function get<T = unknown>(data: Record<any, any>, keys: string | string[]): T | undefined {
+export function get<T = unknown>(data: Record<string | number | symbol, unknown>, keys: string | string[]): T | undefined {
   const parsedKeys  = Array.isArray(keys) ? keys : keys.split('.');
   const key = parsedKeys.shift();
 
@@ -53,6 +53,6 @@ export function set<T = unknown>(data: Record<string, unknown>, keys: string | s
  * @param data - object to check
  * @param keys - keypath to a value
  */
-export function has(data: Record<any, any>, keys: string | string[]): boolean {
+export function has(data: Record<string | number | symbol, unknown>, keys: string | string[]): boolean {
   return get(data, keys) !== undefined;
 }

--- a/src/utils/keypath.ts
+++ b/src/utils/keypath.ts
@@ -4,7 +4,8 @@
  * @param data - object to get value from
  * @param keys - keypath to a value
  */
-export function get<T = unknown>(data: Record<string | number | symbol, unknown>, keys: string | string[]): T | undefined {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unknown can't be used as data parameter is used for recursion
+export function get<T = unknown>(data: Record<string | number | symbol, any>, keys: string | string[]): T | undefined {
   const parsedKeys  = Array.isArray(keys) ? keys : keys.split('.');
   const key = parsedKeys.shift();
 
@@ -53,6 +54,7 @@ export function set<T = unknown>(data: Record<string, unknown>, keys: string | s
  * @param data - object to check
  * @param keys - keypath to a value
  */
-export function has(data: Record<string | number | symbol, unknown>, keys: string | string[]): boolean {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unknown can't be used as data parameter is used for recursion
+export function has(data: Record<string | number | symbol, any>, keys: string | string[]): boolean {
   return get(data, keys) !== undefined;
 }

--- a/src/utils/mapObject.spec.ts
+++ b/src/utils/mapObject.spec.ts
@@ -1,0 +1,40 @@
+import { mapObject } from './mapObject';
+
+describe('mapObject()', () => {
+  it('should map through passed object', () => {
+    const object = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+    };
+
+    const result = mapObject(object, (value) => value * 2);
+
+    expect(result).toEqual({
+      a: 2,
+      b: 4,
+      c: 6,
+      d: 8,
+    });
+  });
+
+  it('should pass key to map function', () => {
+    const key = 'a';
+    const object = { [key]: 'value' };
+
+    /**
+     * Map function
+     *
+     * @param value - entry value
+     * @param k - entry key
+     */
+    const map = (value: string, k: string): string => {
+      expect(k).toEqual(key);
+
+      return value;
+    };
+
+    mapObject(object, map);
+  });
+});

--- a/src/utils/mapObject.ts
+++ b/src/utils/mapObject.ts
@@ -4,6 +4,7 @@
  * @param obj - object to map through
  * @param fn - map function
  */
-export function mapObject<T extends Record<any, any>, M extends Record<keyof T, any>>(obj: T, fn: (entry: T[keyof T], key: string) => M[keyof T]): M {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- any used in generic
+export function mapObject<T extends Record<string | number | symbol, any>, M extends Record<keyof T, any>>(obj: T, fn: (entry: T[keyof T], key: string) => M[keyof T]): M {
   return Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, fn(value, key)])) as M;
 }

--- a/src/utils/mapObject.ts
+++ b/src/utils/mapObject.ts
@@ -1,0 +1,9 @@
+/**
+ * Helper to map through object properties
+ *
+ * @param obj - object to map through
+ * @param fn - map function
+ */
+export function mapObject<T extends Record<any, any>, M extends Record<keyof T, any>>(obj: T, fn: (entry: T[keyof T], key: string) => M[keyof T]): M {
+  return Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, fn(value, key)])) as M;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,7 @@ __metadata:
     stryker-cli: ^1.0.2
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
-    typescript: ^5.0.4
+    typescript: ^5.2.2
   languageName: unknown
   linkType: soft
 
@@ -6658,23 +6658,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes

1. Update entities to accept serialized data into constructor — it enables model initialization using saved data
2. Update BlockNodeData structure to accept any object/array structures as Tool data
3. Update serialized data schema to mark ValueNode/TextNode data with special property `$t`
4. Add private `initialize` methods to EditorDocument and BlockNode classes to create entities from passed serialized data
5. Update ValueNode/TextNode methods call from BlockNode to support any tool data structure

Two issues raised to cover some of added code with integration tests: #40 #41 