### PR TITLE
fix(playground): build script

### DIFF
--- a/packages/dom-adapters/src/index.ts
+++ b/packages/dom-adapters/src/index.ts
@@ -1,1 +1,1 @@
-console.log('dom-adapters');
+export * from './caret/CaretAdapter.js';

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
+    "@editorjs/dom-adapters": "workspace:^",
     "@editorjs/model": "workspace:^",
     "vue": "^3.3.4"
   },

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Node, Input } from './components';
 import { EditorDocument, EditorJSModel } from '@editorjs/model';
-import { data } from '../../model/src/mocks/data.ts';
+import { data } from '@editorjs/model/dist/mocks/data.js';
 
 const document = new EditorDocument(data);
 const model = new EditorJSModel(data);

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { CaretAdapter } from '../../../dom-adapters/src/caret/CaretAdapter';
+import { CaretAdapter } from '@editorjs/dom-adapters';
 import { type EditorJSModel, TextRange } from '@editorjs/model';
 
 const input = ref<HTMLElement | null>(null);

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -32,5 +32,8 @@
     { 
       "path": "../model" 
     },
+    {
+      "path": "../dom-adapters"
+    }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@editorjs/document-playground@workspace:packages/playground"
   dependencies:
+    "@editorjs/dom-adapters": "workspace:^"
     "@editorjs/model": "workspace:^"
     "@types/eslint": "npm:^8"
     "@vitejs/plugin-vue": "npm:^4.2.3"
@@ -583,7 +584,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@editorjs/dom-adapters@workspace:packages/dom-adapters":
+"@editorjs/dom-adapters@workspace:^, @editorjs/dom-adapters@workspace:packages/dom-adapters":
   version: 0.0.0-use.local
   resolution: "@editorjs/dom-adapters@workspace:packages/dom-adapters"
   dependencies:


### PR DESCRIPTION
- Export CaretAdapter from dom-adapters;
- Add dom-adapters as dependency to playground;
- Fix imports in playground.