### PR TITLE
fix(dom-adapters): fix linter, add empty test case

### DIFF
--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -68,6 +68,7 @@ export class CaretAdapter extends EventTarget {
    * @param input - input to watch caret change
    * @param _dataKey - key of data property in block's data that contains input's value
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars -- unused parameter for now
   public attachInput(input: HTMLElement, _dataKey: string): void {
     this.#input = input;
 

--- a/packages/dom-adapters/src/index.spec.ts
+++ b/packages/dom-adapters/src/index.spec.ts
@@ -1,0 +1,5 @@
+describe('Example test', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.vue",
+    "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {

--- a/packages/playground/src/components/Indent.vue
+++ b/packages/playground/src/components/Indent.vue
@@ -18,8 +18,8 @@ const isHidden = ref(props.collapsed ?? true);
     <template v-if="!isHidden">
       <slot />
     </template>
-    <div 
-      v-else 
+    <div
+      v-else
       :class="$style.collapsed"
       @click="isHidden = false"
     >


### PR DESCRIPTION
- Ignore unused parameter for now;
- Add empty test case to generate coverage report in dom-adapters;
- Add lint:ci script to playground, fix linter.