### PR TITLE
feat: improve `BlockToolAdapter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
   "packageManager": "yarn@4.0.1",
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "scripts": {
+    "lint": "yarn workspaces foreach -A run lint",
+    "lint:fix": "yarn workspaces foreach -A run lint --fix"
+  }
 }

--- a/packages/dom-adapters/package.json
+++ b/packages/dom-adapters/package.json
@@ -6,8 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "build": "tsc --project tsconfig.build.json",
+    "dev": "tsc --project tsconfig.build.json --watch",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",

--- a/packages/dom-adapters/package.json
+++ b/packages/dom-adapters/package.json
@@ -33,6 +33,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@editorjs/dom": "^1.0.0",
     "@editorjs/model": "workspace:^"
   }
 }

--- a/packages/dom-adapters/package.json
+++ b/packages/dom-adapters/package.json
@@ -6,8 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
-    "dev": "tsc --project tsconfig.build.json --watch",
+    "build": "tsc --build tsconfig.build.json",
+    "dev": "yarn build --watch",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -238,24 +238,10 @@ export class BlockToolAdapter {
         break;
       }
       case EventAction.Removed: {
-        if (
-          start === end &&
-          start > 0
-        ) {
-          currentElement.value = currentElement.value.slice(0, start - 1) +
-            currentElement.value.slice(end);
-          if (start === 0) {
-            currentElement.setSelectionRange(start, start);
-          } else {
-            currentElement.setSelectionRange(start - 1, start - 1);
-          }
-          break;
-        } else {
-          currentElement.value = currentElement.value.slice(0, start) +
-            currentElement.value.slice(end);
-          currentElement.setSelectionRange(start, start);
-          break;
-        }
+        currentElement.value = currentElement.value.slice(0, start) +
+          currentElement.value.slice(end);
+        currentElement.setSelectionRange(start, start);
+        break;
       }
     }
   };

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -105,7 +105,7 @@ export class BlockToolAdapter {
           break;
         }
         case InputType.DeleteContentBackward: {
-          this.#model.removeText(this.#blockIndex, key, start, end);
+          this.#model.removeText(this.#blockIndex, key, start - 1, end);
           break;
         }
       }
@@ -224,6 +224,7 @@ export class BlockToolAdapter {
           break;
         }
         case EventAction.Removed: {
+          console.log('remove', start, end);
           if (start === end) {
             currentElement.value = currentElement.value.slice(0, start - 1) +
               currentElement.value.slice(end);

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -216,6 +216,13 @@ export class BlockToolAdapter {
     }
   };
 
+  /**
+   * Handles model update events for native inputs and updates DOM
+   * 
+   * @param event - beforeinput event
+   * @param input - input element
+   * @param key - data key input is attached to
+   */
   #handleModelUpdateForNativeInput(event: ModelEvents, input: HTMLInputElement | HTMLTextAreaElement, key: DataKey): void {
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {
       return;
@@ -261,6 +268,13 @@ export class BlockToolAdapter {
     }
   };
 
+  /**
+   * Handles model update events for contenteditable elements and updates DOM
+   * 
+   * @param event - beforeinput event
+   * @param input - input element
+   * @param key - data key input is attached to
+   */
   #handleModelUpdateForContentEditableElement(event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void {
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {
       return;

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -130,18 +130,18 @@ export class BlockToolAdapter {
    * @param input - input element
    * @param key - data key input is attached to
    */
-  #handleBeforeInputEvent = (event: InputEvent, input: HTMLElement, key: DataKey): void => {
+  #handleBeforeInputEvent(event: InputEvent, input: HTMLElement, key: DataKey): void {
     /**
      * We prevent all events to handle them manually via model update
      */
     event.preventDefault();
 
-    const nativeInput = isNativeInput(input);
+    const isInputNative = isNativeInput(input);
     const inputType = event.inputType as InputType;
     let start: number;
     let end: number;
 
-    if (!nativeInput) {
+    if (!isInputNative) {
       const targetRanges = event.getTargetRanges();
       const range = targetRanges[0];
 
@@ -204,7 +204,7 @@ export class BlockToolAdapter {
       case InputType.DeleteSoftLineForward:
       case InputType.DeleteWordBackward:
       case InputType.DeleteWordForward: {
-        if (nativeInput) {
+        if (isInputNative) {
           this.#handleDeleteInNativeInput(event, input, key);
         } else {
           this.#handleDeleteInContentEditable(event, input, key);
@@ -321,9 +321,9 @@ export class BlockToolAdapter {
    * @param caretAdapter - caret adapter instance
    */
   #handleModelUpdate = (event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void => {
-    const nativeInput = isNativeInput(input);
+    const isInputNative = isNativeInput(input);
 
-    if (nativeInput) {
+    if (isInputNative) {
       this.#handleModelUpdateForNativeInput(event, input as HTMLInputElement | HTMLTextAreaElement, key);
     } else {
       this.#handleModelUpdateForContentEditableElement(event, input, key, caretAdapter);

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -8,12 +8,11 @@ import {
 } from '@editorjs/model';
 import { InputType } from './types/InputType.js';
 import { CaretAdapter } from '../caret/CaretAdapter.js';
-import type { NativeInput } from '../utils/index.js';
+import { isNativeInput } from '../utils/index.js';
 import {
   getAbsoluteRangeOffset,
   getBoundaryPointByAbsoluteOffset,
   InputMode,
-  NATIVE_INPUT_SET
 } from '../utils/index.js';
 
 /**
@@ -56,9 +55,7 @@ export class BlockToolAdapter {
    * @param input - input element
    */
   public attachInput(key: DataKey, input: HTMLElement): void {
-    const inputTag = input.tagName as NativeInput;
-
-    if (Boolean(NATIVE_INPUT_SET.has(inputTag))) {
+    if (isNativeInput(input)) {
       this.#mode = InputMode.Native;
     } else if (input.isContentEditable) {
       this.#mode = InputMode.ContentEditable;
@@ -88,12 +85,12 @@ export class BlockToolAdapter {
      */
     event.preventDefault();
 
-    const isNativeInput = this.#mode === InputMode.Native;
+    const nativeInput = this.#mode === InputMode.Native;
     const inputType = event.inputType as InputType;
     let start: number;
     let end: number;
 
-    if (!isNativeInput) {
+    if (!nativeInput) {
       const targetRanges = event.getTargetRanges();
       const range = targetRanges[0];
 
@@ -156,7 +153,7 @@ export class BlockToolAdapter {
       case InputType.DeleteSoftLineForward:
       case InputType.DeleteWordBackward:
       case InputType.DeleteWordForward: {
-        if (isNativeInput && start > 0 && start === end) {
+        if (nativeInput && start > 0 && start === end) {
           // for native input elements, we need to handle backspace manually
           start = start - 1;
         }
@@ -178,7 +175,7 @@ export class BlockToolAdapter {
    * @param caretAdapter - caret adapter instance
    */
   #handleModelUpdate = (event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void => {
-    const isNativeInput = this.#mode === InputMode.Native;
+    const nativeInput = this.#mode === InputMode.Native;
 
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {
       return;
@@ -200,7 +197,7 @@ export class BlockToolAdapter {
       return;
     }
 
-    if (isNativeInput) {
+    if (nativeInput) {
       const currentElement = input as HTMLInputElement | HTMLTextAreaElement;
       const start = currentElement.selectionStart!;
       const end = currentElement.selectionEnd!;

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -218,7 +218,7 @@ export class BlockToolAdapter {
 
   /**
    * Handles model update events for native inputs and updates DOM
-   * 
+   *
    * @param event - model update event
    * @param input - input element
    * @param key - data key input is attached to
@@ -270,10 +270,11 @@ export class BlockToolAdapter {
 
   /**
    * Handles model update events for contenteditable elements and updates DOM
-   * 
+   *
    * @param event - model update event
    * @param input - input element
    * @param key - data key input is attached to
+   * @param caretAdapter - caret adapter instance
    */
   #handleModelUpdateForContentEditableElement(event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void {
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -207,9 +207,9 @@ export class BlockToolAdapter {
       const currentElement = input as HTMLInputElement | HTMLTextAreaElement;
       const [ [start, end] ] = event.detail.index;
 
-      // todo:
-      //  caretAdapter cannot handle native input
-      //  because it doesn't have the content of the input
+      /** 
+       * @todo caretAdapter cannot handle native because it doesn't have the content of the input
+       */
       const action = event.detail.action;
 
       switch (action) {

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -70,7 +70,7 @@ export class BlockToolAdapter {
    * @param key - data key input is attached to
    * @private
    */
-  #handleDeleteInNativeInput = (event: InputEvent, input: HTMLInputElement | HTMLTextAreaElement, key: DataKey): void => {
+  #handleDeleteInNativeInput(event: InputEvent, input: HTMLInputElement | HTMLTextAreaElement, key: DataKey): void {
     const inputType = event.inputType as InputType;
 
     /**
@@ -111,7 +111,7 @@ export class BlockToolAdapter {
    * @param input - input element
    * @param key - data key input is attached to
    */
-  #handleDeleteInContentEditable = (event: InputEvent, input: HTMLElement, key: DataKey): void => {
+  #handleDeleteInContentEditable(event: InputEvent, input: HTMLElement, key: DataKey): void {
     const targetRanges = event.getTargetRanges();
     const range = targetRanges[0];
 
@@ -216,7 +216,7 @@ export class BlockToolAdapter {
     }
   };
 
-  #handleModelUpdateForNativeInput = (event: ModelEvents, input: HTMLInputElement | HTMLTextAreaElement, key: DataKey): void => {
+  #handleModelUpdateForNativeInput(event: ModelEvents, input: HTMLInputElement | HTMLTextAreaElement, key: DataKey): void {
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {
       return;
     }
@@ -261,7 +261,7 @@ export class BlockToolAdapter {
     }
   };
 
-  #handleModelUpdateForContentEditableElement = (event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void => {
+  #handleModelUpdateForContentEditableElement(event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void {
     if (!(event instanceof TextAddedEvent) && !(event instanceof TextRemovedEvent)) {
       return;
     }
@@ -320,7 +320,7 @@ export class BlockToolAdapter {
    * @param key - data key input is attached to
    * @param caretAdapter - caret adapter instance
    */
-  #handleModelUpdate = (event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void => {
+  #handleModelUpdate(event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void {
     const isInputNative = isNativeInput(input);
 
     if (isInputNative) {

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -11,7 +11,7 @@ import { CaretAdapter } from '../caret/CaretAdapter.js';
 import {
   getAbsoluteRangeOffset,
   getBoundaryPointByAbsoluteOffset,
-  isNonTextInput,
+  isNonTextInput
 } from '../utils/index.js';
 
 import { isNativeInput } from '@editorjs/dom';
@@ -112,16 +112,12 @@ export class BlockToolAdapter {
    * @param key - data key input is attached to
    */
   #handleDeleteInContentEditable = (event: InputEvent, input: HTMLElement, key: DataKey): void => {
-    const inputType = event.inputType as InputType;
-    let start: number;
-    let end: number;
-    
     const targetRanges = event.getTargetRanges();
     const range = targetRanges[0];
-    
-    start = getAbsoluteRangeOffset(input, range.startContainer, range.startOffset);
-    end = getAbsoluteRangeOffset(input, range.endContainer, range.endOffset);
-    
+
+    const start: number = getAbsoluteRangeOffset(input, range.startContainer, range.startOffset);
+    const end: number = getAbsoluteRangeOffset(input, range.endContainer, range.endOffset);
+
     this.#model.removeText(this.#blockIndex, key, start, end);
   };
 
@@ -285,7 +281,7 @@ export class BlockToolAdapter {
     const start = rangeIndex[0];
     const end = rangeIndex[1];
 
-    const [startNode, startOffset] = getBoundaryPointByAbsoluteOffset(input,start);
+    const [startNode, startOffset] = getBoundaryPointByAbsoluteOffset(input, start);
     const [endNode, endOffset] = getBoundaryPointByAbsoluteOffset(input, end);
     const range = new Range();
 

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -219,7 +219,7 @@ export class BlockToolAdapter {
   /**
    * Handles model update events for native inputs and updates DOM
    * 
-   * @param event - beforeinput event
+   * @param event - model update event
    * @param input - input element
    * @param key - data key input is attached to
    */
@@ -271,7 +271,7 @@ export class BlockToolAdapter {
   /**
    * Handles model update events for contenteditable elements and updates DOM
    * 
-   * @param event - beforeinput event
+   * @param event - model update event
    * @param input - input element
    * @param key - data key input is attached to
    */

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -215,8 +215,9 @@ export class BlockToolAdapter {
       switch (action) {
         case EventAction.Added: {
           const text = event.detail.data as string;
+          const prevValue = currentElement.value;
 
-          currentElement.value = currentElement.value.slice(0, start) + text + currentElement.value.slice(end);
+          currentElement.value = prevValue.slice(0, start) + text + prevValue.slice(end - 1);
 
           currentElement.setSelectionRange(start + text.length, start + text.length);
           break;

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -217,15 +217,25 @@ export class BlockToolAdapter {
           break;
         }
         case EventAction.Removed: {
-          if (start === end) {
+          if (
+            start === end &&
+            // stop removing if the caret is at the beginning of the input
+            start > 0
+          ) {
             currentElement.value = currentElement.value.slice(0, start - 1) +
               currentElement.value.slice(end);
+            if (start === 0) {
+              currentElement.setSelectionRange(start, start);
+            } else {
+              currentElement.setSelectionRange(start - 1, start - 1);
+            }
+            break;
           } else {
             currentElement.value = currentElement.value.slice(0, start) +
               currentElement.value.slice(end);
+            currentElement.setSelectionRange(start, start);
+            break;
           }
-          currentElement.setSelectionRange(start, start);
-          break;
         }
       }
     } else {

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -156,7 +156,8 @@ export class BlockToolAdapter {
       case InputType.DeleteSoftLineForward:
       case InputType.DeleteWordBackward:
       case InputType.DeleteWordForward: {
-        if (isNativeInput && start > 0) {
+        if (isNativeInput && start > 0 && start === end) {
+          // for native input elements, we need to handle backspace manually
           start = start - 1;
         }
         this.#model.removeText(this.#blockIndex, key, start, end);

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -8,11 +8,11 @@ import {
 } from '@editorjs/model';
 import { InputType } from './types/InputType.js';
 import { CaretAdapter } from '../caret/CaretAdapter.js';
-import { isNativeInput } from '../utils/index.js';
 import {
   getAbsoluteRangeOffset,
   getBoundaryPointByAbsoluteOffset,
   InputMode,
+  isNativeInput
 } from '../utils/index.js';
 
 /**
@@ -157,6 +157,12 @@ export class BlockToolAdapter {
           // for native input elements, we need to handle backspace manually
           start = start - 1;
         }
+        switch (inputType) {
+          case InputType.DeleteSoftLineBackward: {
+            start = 0;
+            break;
+          }
+        }
         this.#model.removeText(this.#blockIndex, key, start, end);
 
         break;
@@ -199,8 +205,7 @@ export class BlockToolAdapter {
 
     if (nativeInput) {
       const currentElement = input as HTMLInputElement | HTMLTextAreaElement;
-      const start = currentElement.selectionStart!;
-      const end = currentElement.selectionEnd!;
+      const [ [start, end] ] = event.detail.index;
 
       // todo:
       //  caretAdapter cannot handle native input

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -32,11 +32,6 @@ export class BlockToolAdapter {
   #blockIndex: number;
 
   /**
-   * Input mode
-   */
-  #mode: InputMode = InputMode.Native;
-
-  /**
    * BlockToolAdapter constructor
    *
    * @param model - EditorJSModel instance
@@ -55,14 +50,6 @@ export class BlockToolAdapter {
    * @param input - input element
    */
   public attachInput(key: DataKey, input: HTMLElement): void {
-    if (isNativeInput(input)) {
-      this.#mode = InputMode.Native;
-    } else if (input.isContentEditable) {
-      this.#mode = InputMode.ContentEditable;
-    } else {
-      throw new Error('BlockToolAdapter: input should be either INPUT, TEXTAREA or contenteditable element');
-    }
-
     const caretAdapter = new CaretAdapter(input, this.#model, this.#blockIndex, key);
 
     input.addEventListener('beforeinput', event => this.#handleBeforeInputEvent(event, input, key));
@@ -140,7 +127,7 @@ export class BlockToolAdapter {
      */
     event.preventDefault();
 
-    const nativeInput = this.#mode === InputMode.Native;
+    const nativeInput = isNativeInput(input);
     const inputType = event.inputType as InputType;
     let start: number;
     let end: number;
@@ -334,7 +321,7 @@ export class BlockToolAdapter {
    * @param caretAdapter - caret adapter instance
    */
   #handleModelUpdate = (event: ModelEvents, input: HTMLElement, key: DataKey, caretAdapter: CaretAdapter): void => {
-    const nativeInput = this.#mode === InputMode.Native;
+    const nativeInput = isNativeInput(input);
 
     if (nativeInput) {
       this.#handleModelUpdateNative(event, input as HTMLInputElement | HTMLTextAreaElement, key);

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -10,7 +10,7 @@ import { useSelectionChange, type Subscriber, type InputWithCaret } from './util
 import {
   getAbsoluteRangeOffset,
   getBoundaryPointByAbsoluteOffset,
-  NATIVE_INPUT_SET
+  isNativeInput
 } from '../utils/index.js';
 import { EventType } from '@editorjs/model';
 
@@ -193,9 +193,7 @@ export class CaretAdapter extends EventTarget {
 
     const input: HTMLElement = this.#input!;
 
-    const isNativeInput = NATIVE_INPUT_SET.has(input.tagName);
-
-    if (isNativeInput) {
+    if (isNativeInput(input)) {
       // skip
     } else {
       const start = getBoundaryPointByAbsoluteOffset(input,

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -10,9 +10,9 @@ import { useSelectionChange, type Subscriber, type InputWithCaret } from './util
 import {
   getAbsoluteRangeOffset,
   getBoundaryPointByAbsoluteOffset,
-  isNativeInput
 } from '../utils/index.js';
 import { EventType } from '@editorjs/model';
+import { isNativeInput } from '@editorjs/dom'; 
 
 /**
  * Caret adapter watches input caret change and passes it to the model

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -201,8 +201,7 @@ export class CaretAdapter extends EventTarget {
     if (isNativeInput(input)) {
       return;
     } else {
-      const start = getBoundaryPointByAbsoluteOffset(input,
-        textIndex[0]);
+      const start = getBoundaryPointByAbsoluteOffset(input, textIndex[0]);
       const end = getBoundaryPointByAbsoluteOffset(input, textIndex[1]);
 
       const selection = document.getSelection()!;

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -193,8 +193,13 @@ export class CaretAdapter extends EventTarget {
 
     const input: HTMLElement = this.#input!;
 
+    /**
+     * For native input, we cannot set caret position programmatically
+     *  because there is no enough information to get `start`
+     *  and `end` points in this case.
+     */
     if (isNativeInput(input)) {
-      // skip
+      return;
     } else {
       const start = getBoundaryPointByAbsoluteOffset(input,
         textIndex[0]);

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -7,7 +7,11 @@ import type {
   CaretManagerEvents
 } from '@editorjs/model';
 import { useSelectionChange, type Subscriber, type InputWithCaret } from './utils/useSelectionChange.js';
-import { getAbsoluteRangeOffset, getBoundaryPointByAbsoluteOffset } from '../utils/index.js';
+import {
+  getAbsoluteRangeOffset,
+  getBoundaryPointByAbsoluteOffset,
+  NATIVE_INPUT_SET
+} from '../utils/index.js';
 import { EventType } from '@editorjs/model';
 
 /**
@@ -187,17 +191,26 @@ export class CaretAdapter extends EventTarget {
       return;
     }
 
-    const start = getBoundaryPointByAbsoluteOffset(this.#input!, textIndex[0]);
-    const end = getBoundaryPointByAbsoluteOffset(this.#input!, textIndex[1]);
+    const input: HTMLElement = this.#input!;
 
-    const selection = document.getSelection()!;
-    const range = new Range();
+    const isNativeInput = NATIVE_INPUT_SET.has(input.tagName);
 
-    range.setStart(...start);
-    range.setEnd(...end);
+    if (isNativeInput) {
+      // skip
+    } else {
+      const start = getBoundaryPointByAbsoluteOffset(input,
+        textIndex[0]);
+      const end = getBoundaryPointByAbsoluteOffset(input, textIndex[1]);
 
-    selection.removeAllRanges();
+      const selection = document.getSelection()!;
+      const range = new Range();
 
-    selection.addRange(range);
+      range.setStart(...start);
+      range.setEnd(...end);
+
+      selection.removeAllRanges();
+
+      selection.addRange(range);
+    }
   }
 }

--- a/packages/dom-adapters/src/caret/CaretAdapter.ts
+++ b/packages/dom-adapters/src/caret/CaretAdapter.ts
@@ -9,10 +9,10 @@ import type {
 import { useSelectionChange, type Subscriber, type InputWithCaret } from './utils/useSelectionChange.js';
 import {
   getAbsoluteRangeOffset,
-  getBoundaryPointByAbsoluteOffset,
+  getBoundaryPointByAbsoluteOffset
 } from '../utils/index.js';
 import { EventType } from '@editorjs/model';
-import { isNativeInput } from '@editorjs/dom'; 
+import { isNativeInput } from '@editorjs/dom';
 
 /**
  * Caret adapter watches input caret change and passes it to the model

--- a/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
+++ b/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
@@ -52,13 +52,6 @@ export const useSelectionChange = createSingleton(() => {
       return false;
     }
 
-    /**
-     * Check, that selection range exists in native inputs
-     */
-    if (selection.rangeCount <= 0) {
-      return false;
-    }
-
     const range = selection.getRangeAt(0);
 
     /**

--- a/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
+++ b/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
@@ -52,6 +52,11 @@ export const useSelectionChange = createSingleton(() => {
       return false;
     }
 
+    if (selection.rangeCount <= 0) {
+      // special case for native input elements
+      return false;
+    }
+
     const range = selection.getRangeAt(0);
 
     /**

--- a/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
+++ b/packages/dom-adapters/src/caret/utils/useSelectionChange.ts
@@ -48,12 +48,14 @@ export const useSelectionChange = createSingleton(() => {
    * @param input - input to check
    */
   function isSelectionRelatedToInput(selection: Selection | null, input: InputWithCaret): boolean {
-    if (!selection) {
+    if (selection === null) {
       return false;
     }
 
+    /**
+     * Check, that selection range exists in native inputs
+     */
     if (selection.rangeCount <= 0) {
-      // special case for native input elements
       return false;
     }
 

--- a/packages/dom-adapters/src/utils/index.ts
+++ b/packages/dom-adapters/src/utils/index.ts
@@ -1,22 +1,2 @@
 export * from './getAbsoluteRangeOffset.js';
 export * from './getRelativeIndex.js';
-
-export enum NativeInput {
-  Textarea = 'TEXTAREA',
-  Input = 'INPUT',
-}
-
-export enum InputMode {
-  Native = 'native',
-  ContentEditable = 'contenteditable',
-}
-
-const NATIVE_INPUT_SET = new Set([NativeInput.Textarea, NativeInput.Input]) as ReadonlySet<string>;
-
-/**
- *
- * @param input
- */
-export function isNativeInput(input: HTMLElement): input is HTMLInputElement | HTMLTextAreaElement {
-  return NATIVE_INPUT_SET.has(input.tagName);
-}

--- a/packages/dom-adapters/src/utils/index.ts
+++ b/packages/dom-adapters/src/utils/index.ts
@@ -13,6 +13,10 @@ export enum InputMode {
 
 const NATIVE_INPUT_SET = new Set([NativeInput.Textarea, NativeInput.Input]) as ReadonlySet<string>;
 
+/**
+ *
+ * @param input
+ */
 export function isNativeInput(input: HTMLElement): input is HTMLInputElement | HTMLTextAreaElement {
   return NATIVE_INPUT_SET.has(input.tagName);
 }

--- a/packages/dom-adapters/src/utils/index.ts
+++ b/packages/dom-adapters/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getAbsoluteRangeOffset.js';
 export * from './getRelativeIndex.js';
+export * from './isNonTextInput.js';

--- a/packages/dom-adapters/src/utils/index.ts
+++ b/packages/dom-adapters/src/utils/index.ts
@@ -1,2 +1,14 @@
 export * from './getAbsoluteRangeOffset.js';
 export * from './getRelativeIndex.js';
+
+export enum NativeInput {
+  Textarea = 'TEXTAREA',
+  Input = 'INPUT',
+}
+
+export enum InputMode {
+  Native = 'native',
+  ContentEditable = 'contenteditable',
+}
+
+export const NATIVE_INPUT_SET = new Set([NativeInput.Textarea, NativeInput.Input]) as ReadonlySet<string>;

--- a/packages/dom-adapters/src/utils/index.ts
+++ b/packages/dom-adapters/src/utils/index.ts
@@ -11,4 +11,8 @@ export enum InputMode {
   ContentEditable = 'contenteditable',
 }
 
-export const NATIVE_INPUT_SET = new Set([NativeInput.Textarea, NativeInput.Input]) as ReadonlySet<string>;
+const NATIVE_INPUT_SET = new Set([NativeInput.Textarea, NativeInput.Input]) as ReadonlySet<string>;
+
+export function isNativeInput(input: HTMLElement): input is HTMLInputElement | HTMLTextAreaElement {
+  return NATIVE_INPUT_SET.has(input.tagName);
+}

--- a/packages/dom-adapters/src/utils/isNonTextInput.ts
+++ b/packages/dom-adapters/src/utils/isNonTextInput.ts
@@ -1,0 +1,24 @@
+enum TextInput {
+  text = 'text', 
+  tel = 'tel',
+  search = 'search',
+  url = 'url',
+  password = 'password',
+}
+
+const TEXT_INPUT_SET = new Set([
+  TextInput.text,
+  TextInput.tel,
+  TextInput.search,
+  TextInput.url,
+  TextInput.password
+]) as ReadonlySet<string>;
+
+/**
+ * Checks if a given HTML input element is not a text input.
+ * @param {HTMLElement} element - The HTML element to check.
+ * @returns {boolean} - Returns true if the element is not a text input, false otherwise.
+ */
+export function isNonTextInput(element: HTMLInputElement): boolean {
+  return !TEXT_INPUT_SET.has(element.type);
+}

--- a/packages/dom-adapters/src/utils/isNonTextInput.ts
+++ b/packages/dom-adapters/src/utils/isNonTextInput.ts
@@ -1,21 +1,22 @@
 enum TextInput {
-  text = 'text', 
-  tel = 'tel',
-  search = 'search',
-  url = 'url',
-  password = 'password',
+  Text = 'text',
+  Tel = 'tel',
+  Search = 'search',
+  Url = 'url',
+  Password = 'password',
 }
 
 const TEXT_INPUT_SET = new Set([
-  TextInput.text,
-  TextInput.tel,
-  TextInput.search,
-  TextInput.url,
-  TextInput.password
+  TextInput.Text,
+  TextInput.Tel,
+  TextInput.Search,
+  TextInput.Url,
+  TextInput.Password,
 ]) as ReadonlySet<string>;
 
 /**
  * Checks if a given HTML input element is not a text input.
+ *
  * @param {HTMLElement} element - The HTML element to check.
  * @returns {boolean} - Returns true if the element is not a text input, false otherwise.
  */

--- a/packages/dom-adapters/src/utils/isNonTextInput.ts
+++ b/packages/dom-adapters/src/utils/isNonTextInput.ts
@@ -1,4 +1,4 @@
-enum TextInput {
+enum TextInputType {
   Text = 'text',
   Tel = 'tel',
   Search = 'search',
@@ -7,11 +7,11 @@ enum TextInput {
 }
 
 const TEXT_INPUT_SET = new Set([
-  TextInput.Text,
-  TextInput.Tel,
-  TextInput.Search,
-  TextInput.Url,
-  TextInput.Password,
+  TextInputType.Text,
+  TextInputType.Tel,
+  TextInputType.Search,
+  TextInputType.Url,
+  TextInputType.Password,
 ]) as ReadonlySet<string>;
 
 /**

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -6,8 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "build": "tsc --project tsconfig.build.json",
+    "dev": "tsc --project tsconfig.build.json --watch",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -24,6 +24,16 @@ model.addEventListener(EventType.Changed, () => {
   document.value = new EditorDocument(model.serialized);
 });
 
+// three types of inputs:
+// ?type=contenteditable
+// ?type=input
+// ?type=textarea
+let type = (new URL(window.location.href).searchParams.get('type') ?? 'contenteditable') as 'contenteditable' | 'input' | 'textarea';
+
+if (type !== 'contenteditable' && type !== 'input' && type !== 'textarea') {
+  type = 'contenteditable';
+}
+
 </script>
 
 <template>
@@ -41,6 +51,7 @@ model.addEventListener(EventType.Changed, () => {
       <div :class="$style.playground">
         <Input
           :model="model"
+          :type="type"
         />
         <pre>{{ serialized }}</pre>
       </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -41,6 +41,7 @@ model.addEventListener(EventType.Changed, () => {
       <div :class="$style.playground">
         <Input
           :model="model"
+          type="input"
         />
         <pre>{{ serialized }}</pre>
       </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -24,16 +24,6 @@ model.addEventListener(EventType.Changed, () => {
   document.value = new EditorDocument(model.serialized);
 });
 
-// three types of inputs:
-// ?type=contenteditable
-// ?type=input
-// ?type=textarea
-let type = (new URL(window.location.href).searchParams.get('type') ?? 'contenteditable') as 'contenteditable' | 'input' | 'textarea';
-
-if (type !== 'contenteditable' && type !== 'input' && type !== 'textarea') {
-  type = 'contenteditable';
-}
-
 </script>
 
 <template>
@@ -51,7 +41,6 @@ if (type !== 'contenteditable' && type !== 'input' && type !== 'textarea') {
       <div :class="$style.playground">
         <Input
           :model="model"
-          :type="type"
         />
         <pre>{{ serialized }}</pre>
       </div>

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -13,22 +13,22 @@ import {
 const input = ref<HTMLElement | null>(null);
 const index = ref<TextRange | null>(null);
 
-const props = defineProps<{
-  /**
-   * Editor js Document model to attach input to
-   */
-  model: EditorJSModel;
-}>();
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Type of the input to be displayed on the page
+     */
+    type?: 'contenteditable' | 'input' | 'textarea',
 
-// three types of inputs:
-// ?type=contenteditable
-// ?type=input
-// ?type=textarea
-let type = (new URL(window.location.href).searchParams.get('type') ?? 'contenteditable') as 'contenteditable' | 'input' | 'textarea';
-
-if (type !== 'contenteditable' && type !== 'input' && type !== 'textarea') {
-  type = 'contenteditable';
-}
+    /**
+     * Editor js Document model to attach input to
+     */
+    model: EditorJSModel;
+  }>(),
+  {
+    type: 'contenteditable'
+  }
+)
 
 onMounted(() => {
   const blockToolAdapter = new BlockToolAdapter(props.model, 0);

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue'
 import { BlockToolAdapter } from '@editorjs/dom-adapters';
 import {
   CaretManagerCaretUpdatedEvent,
@@ -18,6 +18,7 @@ const props = defineProps<{
    * Editor js Document model to attach input to
    */
   model: EditorJSModel;
+  type: 'input' | 'textarea' | 'contenteditable';
 }>();
 
 onMounted(() => {
@@ -34,11 +35,22 @@ onMounted(() => {
 </script>
 <template>
   <div :class="$style.wrapper">
-    <!-- eslint-disable vue/no-v-html -->
     <div
+      v-if="type === 'contenteditable'"
       ref="input"
       contenteditable
       type="text"
+      :class="$style.input"
+    />
+    <input
+      v-else-if="type === 'input'"
+      ref="input"
+      type="text"
+      :class="$style.input"
+    >
+    <textarea
+      v-else-if="type === 'textarea'"
+      ref="input"
       :class="$style.input"
     />
     <div

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -26,9 +26,9 @@ const props = withDefaults(
     model: EditorJSModel;
   }>(),
   {
-    type: 'contenteditable'
+    type: 'contenteditable',
   }
-)
+);
 
 onMounted(() => {
   const blockToolAdapter = new BlockToolAdapter(props.model, 0);

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, ref } from 'vue';
 import { BlockToolAdapter } from '@editorjs/dom-adapters';
 import {
   CaretManagerCaretUpdatedEvent,
@@ -18,8 +18,17 @@ const props = defineProps<{
    * Editor js Document model to attach input to
    */
   model: EditorJSModel;
-  type: 'input' | 'textarea' | 'contenteditable';
 }>();
+
+// three types of inputs:
+// ?type=contenteditable
+// ?type=input
+// ?type=textarea
+let type = (new URL(window.location.href).searchParams.get('type') ?? 'contenteditable') as 'contenteditable' | 'input' | 'textarea';
+
+if (type !== 'contenteditable' && type !== 'input' && type !== 'textarea') {
+  type = 'contenteditable';
+}
 
 onMounted(() => {
   const blockToolAdapter = new BlockToolAdapter(props.model, 0);

--- a/packages/playground/src/components/Input.vue
+++ b/packages/playground/src/components/Input.vue
@@ -89,6 +89,7 @@ onMounted(() => {
 }
 
 .input {
+  border: 0px;
   padding: 8px 14px;
   background-color: rgba(0, 0, 0, 0.2);
   border-radius: 10px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@editorjs/dom-adapters@workspace:packages/dom-adapters"
   dependencies:
+    "@editorjs/dom": "npm:^1.0.0"
     "@editorjs/model": "workspace:^"
     "@jest/globals": "npm:^29.7.0"
     "@stryker-mutator/core": "npm:^7.0.2"
@@ -615,6 +616,22 @@ __metadata:
     typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
+
+"@editorjs/dom@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@editorjs/dom@npm:1.0.0"
+  dependencies:
+    "@editorjs/helpers": "npm:^1.0.0"
+  checksum: d4a4f55ffb31adb4384ad9d75a7bfc2a017e616140059ac8970e6645126ab31afea9ceea24b18820e270269aa87884da6ff46408e3c443578c94d21b57ac9923
+  languageName: node
+  linkType: hard
+
+"@editorjs/helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@editorjs/helpers@npm:1.0.0"
+  checksum: d31286f5c9446a6d5a36802e4ca84939834eee73404804444cbdce2f28edfb91966ecad44340c94942036e96c2912414dc0e4caccf0d20558b895caf6d83fadb
+  languageName: node
+  linkType: hard
 
 "@editorjs/model@workspace:^, @editorjs/model@workspace:packages/model":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Checklist
- [x] Native inputs handling
- Input element
- Textarea element
- Handle non-text input elements
- [x] Contenteditable element handling
- [x] improve playground

- supported `backspace` and `delete` for native inputs
Left todo for native inputs (support all deletion cases manually)
