### PR TITLE
fix(build): use ts references, add hack for esbuild

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,4 +16,4 @@ runs:
 
     - name: Build the package with dependencies
       shell: bash
-      run: yarn workspaces foreach -Rpt --from '${{ inputs.package-name }}' run build
+      run: yarn workspace ${{ inputs.package-name }} run build

--- a/packages/dom-adapters/package.json
+++ b/packages/dom-adapters/package.json
@@ -6,13 +6,14 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",
     "test": "jest",
     "test:coverage": "yarn test --coverage=true",
-    "test:mutations": "stryker run"
+    "test:mutations": "stryker run",
+    "clear": "rm -rf ./dist && rm -rf ./tsconfig.build.tsbuildinfo"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/packages/dom-adapters/package.json
+++ b/packages/dom-adapters/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "dev": "yarn build --watch",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",

--- a/packages/dom-adapters/tsconfig.build.json
+++ b/packages/dom-adapters/tsconfig.build.json
@@ -5,7 +5,7 @@
   ],
   "references": [
     {
-      "path": "../model"
+      "path": "../model/tsconfig.build.json"
     }
   ]
 }

--- a/packages/dom-adapters/tsconfig.json
+++ b/packages/dom-adapters/tsconfig.json
@@ -20,7 +20,7 @@
   ],
   "references": [
     {
-      "path": "../model"
+      "path": "../model/tsconfig.build.json"
     }
   ]
 }

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -6,13 +6,14 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",
     "test": "jest",
     "test:coverage": "yarn test --coverage=true",
-    "test:mutations": "stryker run"
+    "test:mutations": "stryker run",
+    "clear": "rm -rf ./dist && rm -rf ./tsconfig.build.tsbuildinfo"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "dev": "yarn build --watch",
     "lint": "eslint ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "packageManager": "yarn@4.0.1",
   "scripts": {
-    "dev": "vite",
-    "build": "vue-tsc && vite build",
-    "preview": "vite preview",
+    "dev": "yarn build:dependencies && vite",
+    "build": "yarn build:dependencies && vue-tsc && vite build",
+    "preview": "yarn build:dependencies && vite preview",
+    "build:dependencies": "yarn workspaces foreach -Rpt --from $npm_package_name --exclude $npm_package_name run build",
     "lint": "eslint src --ext .ts,.vue",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "packageManager": "yarn@4.0.1",
   "scripts": {
-    "dev": "yarn dev:dependencies & vite",
+    "dev": "concurrently -n \"TSC Watch\",Vite \"yarn dev:dependencies\" \"vite\"",
     "build": "yarn build:dependencies && vue-tsc && vite build",
     "preview": "yarn build:dependencies && vite preview",
     "build:dependencies": "yarn workspaces foreach -Rpt --from $npm_package_name --exclude $npm_package_name run build",
-    "dev:dependencies": "yarn workspaces foreach -Rpt --from $npm_package_name --exclude $npm_package_name run dev",
+    "dev:dependencies": "yarn workspaces foreach -Rp --from $npm_package_name --exclude $npm_package_name run dev",
     "lint": "eslint src --ext .ts,.vue",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix"
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/eslint": "^8",
     "@vitejs/plugin-vue": "^4.2.3",
+    "concurrently": "^8.2.2",
     "eslint": "^8.53.0",
     "eslint-config-codex": "^1.9.1",
     "eslint-plugin-vue": "^9.18.1",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "packageManager": "yarn@4.0.1",
   "scripts": {
-    "dev": "yarn build:dependencies && vite",
+    "dev": "yarn dev:dependencies & vite",
     "build": "yarn build:dependencies && vue-tsc && vite build",
     "preview": "yarn build:dependencies && vite preview",
     "build:dependencies": "yarn workspaces foreach -Rpt --from $npm_package_name --exclude $npm_package_name run build",
+    "dev:dependencies": "yarn workspaces foreach -Rpt --from $npm_package_name --exclude $npm_package_name run dev",
     "lint": "eslint src --ext .ts,.vue",
     "lint:ci": "yarn lint --max-warnings 0",
     "lint:fix": "yarn lint --fix"

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -28,12 +28,6 @@
   "references": [
     { 
       "path": "./tsconfig.node.json" 
-    },
-    { 
-      "path": "../model" 
-    },
-    {
-      "path": "../dom-adapters"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.21.0":
+  version: 7.23.9
+  resolution: "@babel/runtime@npm:7.23.9"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 9a520fe1bf72249f7dd60ff726434251858de15cccfca7aa831bd19d0d3fb17702e116ead82724659b8da3844977e5e13de2bae01eb8a798f2823a669f122be6
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.22.15, @babel/template@npm:^7.3.3":
   version: 7.22.15
   resolution: "@babel/template@npm:7.22.15"
@@ -568,6 +577,7 @@ __metadata:
     "@editorjs/model": "workspace:^"
     "@types/eslint": "npm:^8"
     "@vitejs/plugin-vue": "npm:^4.2.3"
+    concurrently: "npm:^8.2.2"
     eslint: "npm:^8.53.0"
     eslint-config-codex: "npm:^1.9.1"
     eslint-plugin-vue: "npm:^9.18.1"
@@ -2410,7 +2420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2600,6 +2610,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concurrently@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "concurrently@npm:8.2.2"
+  dependencies:
+    chalk: "npm:^4.1.2"
+    date-fns: "npm:^2.30.0"
+    lodash: "npm:^4.17.21"
+    rxjs: "npm:^7.8.1"
+    shell-quote: "npm:^1.8.1"
+    spawn-command: "npm:0.0.2"
+    supports-color: "npm:^8.1.1"
+    tree-kill: "npm:^1.2.2"
+    yargs: "npm:^17.7.2"
+  bin:
+    conc: dist/bin/concurrently.js
+    concurrently: dist/bin/concurrently.js
+  checksum: dcb1aa69d9c611a7bda9d4fc0fe1e388f971d1744acec7e0d52dffa2ef55743f1266ec9292f414c5789b9f61734b3fce772bd005d4de9564a949fb121b97bae1
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
@@ -2655,6 +2685,15 @@ __metadata:
   version: 3.1.2
   resolution: "csstype@npm:3.1.2"
   checksum: 1f39c541e9acd9562996d88bc9fb62d1cb234786ef11ed275567d4b2bd82e1ceacde25debc8de3d3b4871ae02c2933fa02614004c97190711caebad6347debc2
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^2.30.0":
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.21.0"
+  checksum: 70b3e8ea7aaaaeaa2cd80bd889622a4bcb5d8028b4de9162cbcda359db06e16ff6e9309e54eead5341e71031818497f19aaf9839c87d1aba1e27bb4796e758a9
   languageName: node
   linkType: hard
 
@@ -5919,6 +5958,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.1":
   version: 1.5.1
   resolution: "regexp.prototype.flags@npm:1.5.1"
@@ -6210,6 +6256,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shell-quote@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "shell-quote@npm:1.8.1"
+  checksum: af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -6305,6 +6358,13 @@ __metadata:
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: a0f7c9b797eda93139842fd28648e868a9a03ea0ad0d9fa6602a0c1f17b7fb6a7dcca00c144476cccaeaae5042e99a285723b1a201e844ad67221bf5d428f1dc
+  languageName: node
+  linkType: hard
+
+"spawn-command@npm:0.0.2":
+  version: 0.0.2
+  resolution: "spawn-command@npm:0.0.2"
+  checksum: f13e8c3c63abd4a0b52fb567eba5f7940d480c5ed3ec61781d38a1850f179b1196c39e6efa2bbd301f82c1bf1cd7807abc8fbd8fc8e44bcaa3975a124c0d1657
   languageName: node
   linkType: hard
 
@@ -6554,7 +6614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -6641,7 +6701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tree-kill@npm:~1.2.2":
+"tree-kill@npm:^1.2.2, tree-kill@npm:~1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
   bin:
@@ -7235,7 +7295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1":
+"yargs@npm:^17.3.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Typescript references
Now we're using the `--build` flag to build typescript projects. This flag supports project references. Because of that, we don't need to use Yarn Workspaces on CI to build package dependencies topologically. TSC is responsible for that.

## Vite and ESBuild 🤡
ESBuild doesn't support all tsconfig fields. See https://esbuild.github.io/content-types/#tsconfig-json. I've fixed this problem by creating `build:dependencies` script in the playground package. This script builds all workspace dependencies.