### PR TITLE
fix(core): fix composing a data from old version

### DIFF
--- a/packages/core/src/utils/composeDataFromVersion2.ts
+++ b/packages/core/src/utils/composeDataFromVersion2.ts
@@ -1,5 +1,5 @@
 import type { OutputData } from '@editorjs/editorjs';
-import { BlockChildType, type BlockNodeDataSerializedValue, type BlockNodeSerialized, type TextNodeSerialized } from '@editorjs/model';
+import { TextNode, ValueNode, type BlockNodeSerialized } from '@editorjs/model';
 
 /**
  * Converst OutputData from version 2 to version 3
@@ -19,20 +19,19 @@ export function composeDataFromVersion2(data: OutputData): {
           Object
             .entries(block.data as Record<string, unknown>)
             .map(([key, value]) => {
-              const valueObject: BlockNodeDataSerializedValue = {
-                value,
-              };
-
               if (typeof value === 'string') {
-                (valueObject as TextNodeSerialized).$t = BlockChildType.Text;
-              }
+                const textNode = new TextNode({ value });
 
-              return [
-                key, {
-                  value,
-                  $t: typeof value === 'string' ? '$t' : '$v',
-                },
-              ];
+                return [
+                  key, textNode.serialized,
+                ];
+              } else {
+                const valueNode = new ValueNode({ value });
+
+                return [
+                  key, valueNode.serialized,
+                ];
+              }
             })
         ),
       };

--- a/packages/model/src/entities/BlockNode/BlockNode.spec.ts
+++ b/packages/model/src/entities/BlockNode/BlockNode.spec.ts
@@ -552,7 +552,7 @@ describe('BlockNode', () => {
       expect(() => {
         blockNode.updateValue(dataKey, value);
       })
-        .toThrowError(`BlockNode: data with key ${dataKey} does not exist`);
+        .toThrowError(`BlockNode: data with key "${dataKey}" does not exist`);
     });
 
     it('should throw an error if the ValueNode with the passed dataKey is not a ValueNode', () => {
@@ -570,7 +570,7 @@ describe('BlockNode', () => {
       expect(() => {
         blockNode.updateValue(dataKey, value);
       })
-        .toThrowError(`BlockNode: data with key ${dataKey} is not a ValueNode`);
+        .toThrowError(`BlockNode: data with key "${dataKey}" is not a ValueNode`);
     });
   });
 

--- a/packages/model/src/entities/BlockNode/index.ts
+++ b/packages/model/src/entities/BlockNode/index.ts
@@ -325,11 +325,11 @@ export class BlockNode extends EventBus {
    */
   #validateKey(key: DataKey, Node?: typeof ValueNode | typeof TextNode): void {
     if (!has(this.#data, key as string)) {
-      throw new Error(`BlockNode: data with key ${key} does not exist`);
+      throw new Error(`BlockNode: data with key "${key}" does not exist`);
     }
 
     if (Node && !(get(this.#data, key as string) instanceof Node)) {
-      throw new Error(`BlockNode: data with key ${key} is not a ${Node.name}`);
+      throw new Error(`BlockNode: data with key "${key}" is not a ${Node.name}`);
     }
   }
 
@@ -430,12 +430,10 @@ export class BlockNode extends EventBus {
 export type {
   BlockToolName,
   DataKey,
-  BlockNodeSerialized,
-  BlockNodeDataSerializedValue
+  BlockNodeSerialized
 };
 
 export {
   createBlockToolName,
-  createDataKey,
-  BlockChildType
+  createDataKey
 };


### PR DESCRIPTION
Now when you type something in the Editor, you will see an error:

<img width="663" alt="image" src="https://github.com/user-attachments/assets/d3767bd1-b994-4067-9849-c6e5e963a6bf">


This error happen because we're validating model node values to be `TextNode` or `ValueNode`. But current `composeDataFromVersion2` returns just an `object`.


```ts
 if (Node && !(get(this.#data, key as string) instanceof Node)) {
   throw new Error(`BlockNode: data with key "${key}" is not a ${Node.name}`);
 }
```

## Solution 

Now `composeDataFromVersion2` creates either `TextNode` or `ValueNode`