### PR TITLE
fix(caret-adapter): avoid selection change triggering

### DIFF
--- a/packages/dom-adapters/src/CaretAdapter/index.ts
+++ b/packages/dom-adapters/src/CaretAdapter/index.ts
@@ -256,7 +256,7 @@ export class CaretAdapter extends EventTarget {
     range.setStart(...start);
     range.setEnd(...end);
 
-    selection.removeAllRanges();
+    currentRange.detach();
 
     selection.addRange(range);
   }


### PR DESCRIPTION
## Changes
- now if selection from `selectionchange` event differs with dom selection, we change dom selection with 

```
selection.removeAllRanges();  // <---- this triggers `selectionchange` event with empty bounds and selection collapses 
selection.addRange(range);
```

### Why only in r2l selections?
to compare dom selection with model one, we use `getBoundaryPointByAbsoluteOffset()` that returns right bound of the left node, however selection expects left bound of the right column:

```... | \tag ...``` !== ```... \tag | ...```
and selection updates with `selection.removeAllRanges()` causing an issue