### PR TITLE
feat(ui, dom-adapters): delegated beforeinput

### DIFF
--- a/packages/core/src/tools/internal/block-tools/paragraph/index.ts
+++ b/packages/core/src/tools/internal/block-tools/paragraph/index.ts
@@ -50,6 +50,8 @@ export class Paragraph implements BlockTool<ParagraphData, ParagraphConfig> {
   public render(): HTMLElement {
     const wrapper = document.createElement('div');
 
+    wrapper.classList.add('editorjs-paragraph');
+
     wrapper.contentEditable = 'true';
     wrapper.style.outline = 'none';
     wrapper.style.whiteSpace = 'pre-wrap';

--- a/packages/dom-adapters/.eslintrc.yml
+++ b/packages/dom-adapters/.eslintrc.yml
@@ -27,6 +27,8 @@ rules:
     - 0
   '@typescript-eslint/no-unsafe-argument':
     - 0
+  'jsdoc/require-returns-type':
+    - 0
 env:
   browser: true
 

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -176,7 +176,7 @@ export class BlockToolAdapter implements BlockToolAdapterInterface {
       return false;
     });
 
-    return currentInput !== undefined ? [currentInput[0], currentInput[1]] : null;
+    return currentInput !== undefined ? currentInput : null;
   }
 
   /**
@@ -187,7 +187,7 @@ export class BlockToolAdapter implements BlockToolAdapterInterface {
   #processDelegatedBeforeInput(event: BeforeInputUIEvent): void {
     const [dataKey, currentInput] = this.#findFocusedInput() ?? [];
 
-    if (!currentInput || !dataKey) {
+    if (currentInput === undefined || dataKey === undefined) {
       return;
     }
 

--- a/packages/dom-adapters/src/BlockToolAdapter/index.ts
+++ b/packages/dom-adapters/src/BlockToolAdapter/index.ts
@@ -12,14 +12,14 @@ import {
   TextAddedEvent,
   TextRemovedEvent
 } from '@editorjs/model';
-import type { 
+import type {
   EventBus,
   BlockToolAdapter as BlockToolAdapterInterface,
   CoreConfig,
   BeforeInputUIEvent,
   BeforeInputUIEventPayload
- } from '@editorjs/sdk';
- import { BeforeInputUIEventName } from '@editorjs/sdk';
+} from '@editorjs/sdk';
+import { BeforeInputUIEventName } from '@editorjs/sdk';
 import type { CaretAdapter } from '../CaretAdapter/index.js';
 import type { FormattingAdapter } from '../FormattingAdapter/index.js';
 import {
@@ -148,7 +148,7 @@ export class BlockToolAdapter implements BlockToolAdapterInterface {
 
   /**
    * Check current selection and find it across all attached inputs
-   * 
+   *
    * @returns tuple of data key and input element or null if no focused input is found
    */
   #findFocusedInput(): [DataKey, HTMLElement] | null {
@@ -165,11 +165,14 @@ export class BlockToolAdapter implements BlockToolAdapterInterface {
        */
       if (input.isContentEditable) {
         const selection = window.getSelection();
+
         if (selection !== null && selection.rangeCount > 0) {
           const range = selection.getRangeAt(0);
+
           return input.contains(range.startContainer);
         }
       }
+
       return false;
     });
 

--- a/packages/sdk/src/entities/EventBus/events/ui/BeforeInputUIEvent.ts
+++ b/packages/sdk/src/entities/EventBus/events/ui/BeforeInputUIEvent.ts
@@ -15,7 +15,7 @@ export interface BeforeInputUIEventPayload {
    * This may be an empty string if the change doesn't insert text
    * (for example, when deleting characters).
    */
-  data: string | null;
+  data: string;
 
   /**
    * Same as 'beforeinput' event's inputType
@@ -26,6 +26,11 @@ export interface BeforeInputUIEventPayload {
    * Same as 'beforeinput' event's isComposing
    */
   isComposing: boolean;
+
+  /**
+   * Objects that will be affected by a change to the DOM if the input event is not canceled.
+   */
+  targetRanges: StaticRange[];
 }
 
 /**

--- a/packages/ui/src/Blocks/Blocks.module.pcss
+++ b/packages/ui/src/Blocks/Blocks.module.pcss
@@ -1,3 +1,15 @@
 .blocks {
   outline: none;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+/**
+ * Zero-width space wrapper that will prevent Safari from deleting blocks if there is no content in host
+ */
+.host-holder {
+  line-height: 0;
+  width: 0;
+  height: 0;
+  user-select: none;
 }

--- a/packages/ui/src/Blocks/Blocks.ts
+++ b/packages/ui/src/Blocks/Blocks.ts
@@ -112,8 +112,6 @@ export class BlocksUI implements EditorjsPlugin {
         data = e.dataTransfer?.getData('text/plain') ?? e.data ?? '';
       }
 
-      console.log('ragne', window.getSelection()?.getRangeAt(0));
-
       this.#eventBus.dispatchEvent(new BeforeInputUIEvent({
         data,
         inputType: e.inputType,

--- a/packages/ui/src/Blocks/Blocks.ts
+++ b/packages/ui/src/Blocks/Blocks.ts
@@ -9,6 +9,7 @@ import {
 } from '@editorjs/sdk';
 import type { EventBus } from '@editorjs/sdk';
 import Style from './Blocks.module.pcss';
+import { isNativeInput } from '@editorjs/dom';
 
 /**
  * Editor's main UI renderer for HTML environment
@@ -85,19 +86,59 @@ export class BlocksUI implements EditorjsPlugin {
 
     blocksHolder.classList.add(Style['blocks']);
 
-    blocksHolder.contentEditable = 'false';
+    blocksHolder.contentEditable = 'true';
+
+    /**
+     * Workaround Safari behavior when it deletes blocks if there is no content in them
+     * E.g. when you delete all content in the only block, it deletes the block
+     */
+    this.#addHostHolder(blocksHolder);
 
     blocksHolder.addEventListener('beforeinput', (e) => {
+      e.preventDefault();
+
+      const isInputNative = isNativeInput(e.target as HTMLElement);
+
+      let data: string;
+
+      /**
+       * For native inputs data for those events comes from event.data property
+       * while for contenteditable elements it's stored in event.dataTransfer
+       * @see https://www.w3.org/TR/input-events-2/#overview
+       */
+      if (isInputNative) {
+        data = e.data ?? '';
+      } else {
+        data = e.dataTransfer?.getData('text/plain') ?? e.data ?? '';
+      }
+
+      console.log('ragne', window.getSelection()?.getRangeAt(0));
+
       this.#eventBus.dispatchEvent(new BeforeInputUIEvent({
-        data: e.data,
+        data,
         inputType: e.inputType,
         isComposing: e.isComposing,
+        targetRanges: e.getTargetRanges(),
       }));
     });
 
     editorHolder.appendChild(blocksHolder);
 
     return blocksHolder;
+  }
+
+  /**
+   * Adds host holder that will prevent Safari from deleting blocks if there is no content host
+   * @param blocksHolder - blocks holder element
+   */
+  #addHostHolder(blocksHolder: HTMLElement): void {
+    const zeroWidthSpaceWrapper = document.createElement('span');
+    const zeroWidthSpace = document.createTextNode('\u200B');
+
+    zeroWidthSpaceWrapper.classList.add(Style['host-holder']);
+    zeroWidthSpaceWrapper.appendChild(zeroWidthSpace);
+
+    blocksHolder.appendChild(zeroWidthSpaceWrapper);
   }
 
   /**

--- a/packages/ui/src/Toolbox/Toolbox.ts
+++ b/packages/ui/src/Toolbox/Toolbox.ts
@@ -55,7 +55,7 @@ export class ToolboxUI implements EditorjsPlugin {
     this.#eventBus.addEventListener(`core:${CoreEventType.ToolLoaded}`, (event: ToolLoadedCoreEvent) => {
       const { tool } = event.detail;
 
-      if ('isBlock' in tool && tool.isBlock()) {
+      if (tool?.isBlock?.() === true) {
         this.addTool(tool);
       }
     });

--- a/packages/ui/src/main.module.pcss
+++ b/packages/ui/src/main.module.pcss
@@ -8,3 +8,8 @@
 
   width: 100%;
 }
+
+.paragraph {
+  min-height: 1em;
+}
+


### PR DESCRIPTION
1) Blocks holder element (Host) is now contenteditable
2) Host dispatches 'ui:before-input' event
3) BlockToolAdapter subscribed to 'ui:before-input' and delegates it to attached inputs