### PR TITLE
imp(): implement all operations transformations

### DIFF
--- a/packages/collaboration-manager/src/Operation.spec.ts
+++ b/packages/collaboration-manager/src/Operation.spec.ts
@@ -103,7 +103,7 @@ describe('Operation', () => {
         const localOp = createOperation(OperationType.Insert, 0, 'abc');
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([6, 6]);
+        expect(transformedOp?.index.textRange).toEqual([6, 6]);
       });
 
       it('should transform a received operation if it is at the same position as a local one', () => {
@@ -111,7 +111,7 @@ describe('Operation', () => {
         const localOp = createOperation(OperationType.Insert, 0, 'def');
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([3, 3]);
+        expect(transformedOp?.index.textRange).toEqual([3, 3]);
       });
 
       it('should not change the text index if local op is a Block operation', () => {
@@ -122,7 +122,7 @@ describe('Operation', () => {
         } ]);
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([0, 0]);
+        expect(transformedOp?.index.textRange).toEqual([0, 0]);
       });
 
       it('should not change the operation if local op is a Block operation after a received one', () => {
@@ -152,7 +152,7 @@ describe('Operation', () => {
 
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.blockIndex).toEqual(2);
+        expect(transformedOp?.index.blockIndex).toEqual(2);
       });
 
       it('should adjust the block index if local op is a Block operation at the same index as a received one', () => {
@@ -167,7 +167,7 @@ describe('Operation', () => {
 
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.blockIndex).toEqual(1);
+        expect(transformedOp?.index.blockIndex).toEqual(1);
       });
     });
 
@@ -185,7 +185,7 @@ describe('Operation', () => {
         const localOp = createOperation(OperationType.Delete, 0, 'abc');
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([0, 0]);
+        expect(transformedOp?.index.textRange).toEqual([0, 0]);
       });
 
       it('should transform a received operation if it is at the same position as a local one', () => {
@@ -193,7 +193,7 @@ describe('Operation', () => {
         const localOp = createOperation(OperationType.Delete, 3, 'def');
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([0, 0]);
+        expect(transformedOp?.index.textRange).toEqual([0, 0]);
       });
 
       it('should not change the text index if local op is a Block operation', () => {
@@ -204,7 +204,7 @@ describe('Operation', () => {
         } ]);
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([1, 1]);
+        expect(transformedOp?.index.textRange).toEqual([1, 1]);
       });
 
       it('should not change the text index if local op is a Block operation', () => {
@@ -215,7 +215,7 @@ describe('Operation', () => {
         } ]);
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.textRange).toEqual([0, 0]);
+        expect(transformedOp?.index.textRange).toEqual([0, 0]);
       });
 
       it('should not change the operation if local op is a Block operation after a received one', () => {
@@ -245,7 +245,7 @@ describe('Operation', () => {
 
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.blockIndex).toEqual(0);
+        expect(transformedOp?.index.blockIndex).toEqual(0);
       });
 
       it('should adjust the block index if local op is a Block operation at the same index as a received one', () => {
@@ -260,7 +260,23 @@ describe('Operation', () => {
 
         const transformedOp = receivedOp.transform(localOp);
 
-        expect(transformedOp.index.blockIndex).toEqual(0);
+        expect(transformedOp?.index.blockIndex).toEqual(0);
+      });
+
+      it('should return null if the transformed text range becomes negative', () => {
+        const receivedOp = createOperation(OperationType.Delete, 1, 'abc');
+        const localOp = createOperation(OperationType.Delete, 0, 'defghijk');  // Delete more characters than available
+        const transformedOp = receivedOp.transform(localOp);
+
+        expect(transformedOp).toBeNull();
+      });
+
+      it('should return null if the transformed text range becomes negative for Insert operation', () => {
+        const receivedOp = createOperation(OperationType.Insert, 1, 'abc');
+        const localOp = createOperation(OperationType.Delete, 0, 'defghijk');  // Delete more characters than available
+        const transformedOp = receivedOp.transform(localOp);
+
+        expect(transformedOp).toBeNull();
       });
     });
   });

--- a/packages/collaboration-manager/src/UndoRedoManager.spec.ts
+++ b/packages/collaboration-manager/src/UndoRedoManager.spec.ts
@@ -5,6 +5,25 @@ import { UndoRedoManager } from './UndoRedoManager.js';
 
 const userId = 'user';
 
+/**
+ * Helper function to create test operations
+ */
+function createOperation(index: number, text: string): Operation {
+  return new Operation(
+    OperationType.Insert,
+    new IndexBuilder()
+      .addBlockIndex(index)
+      .build(),
+    {
+      payload: [{
+        name: 'paragraph',
+        data: { text },
+      }],
+    },
+    userId
+  );
+}
+
 describe('UndoRedoManager', () => {
   it('should return inverted operation on undo', () => {
     const manager = new UndoRedoManager();
@@ -107,5 +126,136 @@ describe('UndoRedoManager', () => {
     const result = manager.redo();
 
     expect(result).toBeUndefined();
+  });
+
+  describe('transform operations', () => {
+    it('should transform undo stack operations', () => {
+      const manager = new UndoRedoManager();
+      const op1 = createOperation(0, 'first');
+      const op2 = createOperation(1, 'second');
+      
+      // Put operations in undo stack
+      manager.put(op1);
+      manager.put(op2);
+
+      // Create operation that will affect the stack
+      const transformingOp = createOperation(0, 'transform');
+
+      // Mock transform method
+      const transformSpy = jest.spyOn(op2, 'transform').mockReturnValue(createOperation(2, 'transformed'));
+      
+      manager.transformUndoStack(transformingOp);
+
+      expect(transformSpy).toHaveBeenCalledWith(transformingOp);
+    });
+
+    it('should transform redo stack operations', () => {
+      const manager = new UndoRedoManager();
+      const op1 = createOperation(0, 'first');
+      
+      // Put operation and undo it to move it to redo stack
+      manager.put(op1);
+      manager.undo();
+
+      // Create operation that will affect the stack
+      const transformingOp = createOperation(0, 'transform');
+
+      // Mock transform method
+      const transformSpy = jest.spyOn(op1, 'transform').mockReturnValue(createOperation(1, 'transformed'));
+      
+      manager.transformRedoStack(transformingOp);
+
+      expect(transformSpy).toHaveBeenCalledWith(transformingOp);
+    });
+
+    it('should remove operations from stack if transform returns null', () => {
+      const manager = new UndoRedoManager();
+      const op1 = createOperation(0, 'first');
+      const op2 = createOperation(1, 'second');
+      
+      manager.put(op1);
+      manager.put(op2);
+
+      // Mock transform to return null
+      jest.spyOn(op2, 'transform').mockReturnValue(null);
+      
+      const transformingOp = createOperation(0, 'transform');
+      manager.transformUndoStack(transformingOp);
+
+      // Try to undo twice - second undo should return undefined since op2 was removed
+      expect(manager.undo()).toBeDefined();
+      expect(manager.undo()).toBeUndefined();
+    });
+
+    it('should handle empty stacks during transformation', () => {
+      const manager = new UndoRedoManager();
+      const transformingOp = createOperation(0, 'transform');
+
+      // Should not throw when transforming empty stacks
+      expect(() => {
+        manager.transformUndoStack(transformingOp);
+        manager.transformRedoStack(transformingOp);
+      }).not.toThrow();
+    });
+
+    it('should transform both undo and redo stacks when operations are undone', () => {
+      const manager = new UndoRedoManager();
+      const op1 = createOperation(0, 'first');
+      const op2 = createOperation(1, 'second');
+      
+      // Put operations in undo stack
+      manager.put(op1);
+      manager.put(op2);
+      
+      // Undo op2 to move it to redo stack
+      manager.undo();
+
+      // Create operation that will affect both stacks
+      const transformingOp = createOperation(0, 'transform');
+
+      // Mock transform methods
+      const undoStackSpy = jest.spyOn(op1, 'transform').mockReturnValue(createOperation(1, 'transformed-undo'));
+      const redoStackSpy = jest.spyOn(op2, 'transform').mockReturnValue(createOperation(2, 'transformed-redo'));
+      
+      // Transform both stacks
+      manager.transformUndoStack(transformingOp);
+      manager.transformRedoStack(transformingOp);
+
+      expect(undoStackSpy).toHaveBeenCalledWith(transformingOp);
+      expect(redoStackSpy).toHaveBeenCalledWith(transformingOp);
+    });
+
+    it('should maintain correct operation order after transforming both stacks', () => {
+      const manager = new UndoRedoManager();
+      const op1 = createOperation(0, 'first');
+      const op2 = createOperation(1, 'second');
+      const op3 = createOperation(2, 'third');
+      
+      // Setup initial state
+      manager.put(op1);
+      manager.put(op2);
+      manager.put(op3);
+      
+      // Move op3 and op2 to redo stack
+      manager.undo(); // undo op3
+      manager.undo(); // undo op2
+
+      const transformingOp = createOperation(0, 'transform');
+      
+      // Mock transforms to return operations with shifted indices
+      jest.spyOn(op1, 'transform').mockReturnValue(createOperation(1, 'transformed-1'));
+      jest.spyOn(op2, 'transform').mockReturnValue(createOperation(2, 'transformed-2'));
+      jest.spyOn(op3, 'transform').mockReturnValue(createOperation(3, 'transformed-3'));
+      
+      manager.transformUndoStack(transformingOp);
+      manager.transformRedoStack(transformingOp);
+
+      // Verify operations can be redone in correct order
+      const redoOp1 = manager.redo();
+      const redoOp2 = manager.redo();
+      
+      expect(redoOp1?.index.toString()).toBe('2'); // transformed op2
+      expect(redoOp2?.index.toString()).toBe('3'); // transformed op3
+    });
   });
 });

--- a/packages/collaboration-manager/src/UndoRedoManager.ts
+++ b/packages/collaboration-manager/src/UndoRedoManager.ts
@@ -57,4 +57,28 @@ export class UndoRedoManager {
     this.#undoStack.push(operation);
     this.#redoStack = [];
   }
+
+  public transformUndoStack(operation: Operation): void {
+    this.transformStack(operation, this.#undoStack);
+  }
+
+  public transformRedoStack(operation: Operation): void {
+    this.transformStack(operation, this.#redoStack);
+  }
+
+  public transformStack(operation: Operation, stack: Operation[]): void {
+    const transformed = stack.flatMap((op) => {
+      const transformedOp = op.transform(operation);
+
+      if (transformedOp === null) {
+        return []
+      }
+
+      return [ transformedOp ];
+    })
+
+    stack.length = 0;
+    stack.push(...transformed);
+
+  }
 }

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -29,7 +29,8 @@ onMounted(() => {
     holder: document.getElementById('editorjs') as HTMLElement,
     userId: userId,
     documentId: 'test',
-    // collaborationServer: 'ws://localhost:8080',
+    // collaborationServer: 'wss://lirili-larila.codex.so/',
+    collaborationServer: 'ws://localhost:8080',
     data: {
       blocks: [
         {

--- a/packages/ui/src/Blocks/Blocks.ts
+++ b/packages/ui/src/Blocks/Blocks.ts
@@ -70,10 +70,14 @@ export class BlocksUI implements EditorjsPlugin {
       if (e.shiftKey) {
         this.#eventBus.dispatchEvent(new Event('core:redo'));
 
+        e.preventDefault();
+
         return;
       }
 
       this.#eventBus.dispatchEvent(new Event('core:undo'));
+
+      e.preventDefault();
     });
   }
 


### PR DESCRIPTION
## Changes
- `OperationsBatch` now extends `Operation`
1. It has own lits of operations
2. It can transform list of operations against one
3. It can inverse list of operations
- Added `OperationType.Neutral` - operation, that does not affect model on apply, so could be skipped, this type of operations could appear after transformation
- Now Undo/Redo stacks and current OperationsBatch are transformed on event, got from server (with userId !== userId of the current client)
- Supported all transformations for Operation