### PR TITLE
Fix DOM inline formatting

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,5 @@
 import { CollaborationManager } from '@editorjs/collaboration-manager';
 import { type DocumentId, EditorJSModel, EventType } from '@editorjs/model';
-import type { ServiceIdentifier } from 'inversify';
 import { Container } from 'inversify';
 import {
   type BlockToolConstructor,
@@ -181,9 +180,9 @@ export default class Core {
        * @todo add e2e initialization tests
        * Currently only BlockRenderer would be enough, but that would be hard to debug. Easier just add every module here
        */
-      [BlockRenderer, BlocksManager, SelectionManager].forEach((module) => {
-        this.#iocContainer.get(module as ServiceIdentifier);
-      });
+      this.#iocContainer.get(BlockRenderer);
+      this.#iocContainer.get(BlocksManager);
+      this.#iocContainer.get(SelectionManager);
 
       this.#initializePlugins();
       await this.#initializeTools();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 import { CollaborationManager } from '@editorjs/collaboration-manager';
 import { type DocumentId, EditorJSModel, EventType } from '@editorjs/model';
+import type { ServiceIdentifier } from 'inversify';
 import { Container } from 'inversify';
 import {
   type BlockToolConstructor,
@@ -174,13 +175,18 @@ export default class Core {
 
       this.#initializeAdapter();
 
+      /**
+       * Need to initialize internal modules before plugins and tools
+       * @todo think of how to remove this?
+       * @todo add e2e initialization tests
+       * Currently only BlockRenderer would be enough, but that would be hard to debug. Easier just add every module here
+       */
+      [BlockRenderer, BlocksManager, SelectionManager].forEach((module) => {
+        this.#iocContainer.get(module as ServiceIdentifier);
+      });
+
       this.#initializePlugins();
-
       await this.#initializeTools();
-
-      this.#iocContainer.get(SelectionManager);
-      this.#iocContainer.get(BlocksManager);
-      this.#iocContainer.get(BlockRenderer);
 
       this.#model.initializeDocument({ blocks });
       this.#collaborationManager.connect();

--- a/packages/dom-adapters/src/index.ts
+++ b/packages/dom-adapters/src/index.ts
@@ -13,6 +13,8 @@ import type { BlockId } from '@editorjs/model';
 import { Container } from 'inversify';
 import { TOKENS } from './tokens.js';
 import type { CoreConfig } from '@editorjs/sdk';
+import { FormattingAdapter } from './FormattingAdapter/index.js';
+import { CaretAdapter } from './CaretAdapter/index.js';
 
 export * from './CaretAdapter/index.js';
 export * from './FormattingAdapter/index.js';
@@ -49,6 +51,12 @@ export class DOMAdapters implements EditorJSAdapterPlugin {
       .bind(DOMBlockToolAdapter)
       .toSelf()
       .inTransientScope();
+
+    /**
+     * Initialize singleton adapters
+     */
+    this.#iocContainer.get(FormattingAdapter);
+    this.#iocContainer.get(CaretAdapter);
   }
 
   /**


### PR DESCRIPTION
Inline tools were not applied to the DOM tree because Adapter was initialized after tools were loaded. Caret and Formatting adapters were not initialized at all before first BlockToolAdapter is created

Fixed the order of initialization in this PR