### PR TITLE
fix(ui): remove blocks holder listeners and detach it on destroy

### DIFF
--- a/packages/ui/src/Blocks/Blocks.ts
+++ b/packages/ui/src/Blocks/Blocks.ts
@@ -48,6 +48,12 @@ export class BlocksUI implements EditorjsPlugin {
   #api: EditorAPI;
 
   /**
+   * Controls the lifetime of the DOM listeners attached to the blocks holder
+   * so they can all be removed at once on destroy()
+   */
+  #listenersController = new AbortController();
+
+  /**
    * EditorUI constructor method
    * @param params - Plugin parameters
    */
@@ -114,7 +120,7 @@ export class BlocksUI implements EditorjsPlugin {
         targetRanges: e.getTargetRanges(),
         isCrossInputSelection,
       }));
-    });
+    }, { signal: this.#listenersController.signal });
 
     blocksHolder.addEventListener('keydown', (e) => {
       if (e.code !== 'KeyZ') {
@@ -136,7 +142,7 @@ export class BlocksUI implements EditorjsPlugin {
       this.#api.document.undo();
 
       e.preventDefault();
-    });
+    }, { signal: this.#listenersController.signal });
 
     return blocksHolder;
   }
@@ -223,5 +229,15 @@ export class BlocksUI implements EditorjsPlugin {
   public destroy(): void {
     this.#blocks.forEach(block => block.remove());
     this.#blocks = [];
+
+    /**
+     * Removes the beforeinput/keydown listeners attached to the blocks holder
+     */
+    this.#listenersController.abort();
+
+    /**
+     * Detach the blocks holder itself so it doesn't linger in the DOM
+     */
+    this.#blocksHolder.remove();
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -72,7 +72,7 @@ export class EditorjsUI implements EditorjsPlugin {
    * Method to destroy the plugin
    */
   public destroy(): void {
-    // Cleanup if needed
+    this.#editorWrapper.remove();
   }
 
   /**


### PR DESCRIPTION
Closes #170

`BlocksUI` attaches `beforeinput` and `keydown` listeners to the blocks holder in `#prepareBlocksHolder()` but `destroy()` never removes them, and the holder itself is never detached. If a holder is reused or a new instance is created, the old listeners keep firing alongside the new ones (duplicate `BeforeInputUIEvent` dispatches and stale undo/redo handling).

This wires both listeners to a single `AbortController` and calls `.abort()` in `destroy()`, which is the pattern the issue suggested. `destroy()` now also detaches `#blocksHolder`, and `EditorjsUI.destroy()` (previously a no-op) removes its `#editorWrapper` so the whole subtree comes off the page.

The `ui` package has no test runner wired up yet (no `Blocks.spec.ts` and no `test` script), so this doesn't add a spec. Happy to follow up with one if you want the test harness set up here.
