### PR TITLE
fix(ci): resolve depth-2 workspaces in should-run-ci.sh

### DIFF
--- a/.github/scripts/should-run-ci.sh
+++ b/.github/scripts/should-run-ci.sh
@@ -57,30 +57,27 @@ if [ -z "$RESOLVED_BASE_REF" ]; then
 fi
 
 # Build an index of workspace packages: one "<package-name> <directory>" record per line.
-# Workspace locations are derived from the root package.json "workspaces" globs, so nested
-# roots (packages/tools/*, packages/plugins/*, and any future ones) are picked up automatically.
+# Locations come from yarn itself, so any workspace layout (nested roots like packages/tools/*
+# and packages/plugins/*, or anything added later) is picked up without teaching this script
+# about it. The root workspace (location ".") is dropped: it is not a package that can change.
+# Both field orders are accepted so a change in yarn's output ordering cannot silently break this.
 build_workspace_index() {
-  local globs glob dir name
-
-  globs=$(sed -n '/"workspaces"/,/\]/p' package.json 2>/dev/null \
-    | grep -o '"[^"]*"' | tr -d '"' | grep -v '^workspaces$')
-
-  # Fallback to the historical layout if the root manifest can't be parsed
-  if [ -z "$globs" ]; then
-    debug "Warning: could not read workspaces from package.json, falling back to packages/*"
-    globs="packages/*"
-  fi
-
-  for glob in $globs; do
-    for dir in $glob; do
-      [ -f "$dir/package.json" ] || continue
-      name=$(sed -n 's/^[[:space:]]*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" | head -1)
-      [ -n "$name" ] && echo "$name $dir"
-    done
-  done
+  yarn workspaces list --json 2>/dev/null \
+    | sed -n -e 's/.*"location":"\([^"]*\)","name":"\([^"]*\)".*/\2 \1/p' \
+             -e 's/.*"name":"\([^"]*\)","location":"\([^"]*\)".*/\1 \2/p' \
+    | grep -v ' \.$'
 }
 
 WORKSPACES=$(build_workspace_index)
+
+# Fail open: if the workspace list is unavailable (no yarn, no node, unexpected output),
+# run CI instead of silently skipping it - a false negative here means a package is never
+# validated on the PR, which is far worse than an unnecessary run.
+if [ -z "$WORKSPACES" ]; then
+  debug "Warning: could not list workspaces via yarn"
+  debug "Assuming all changes are relevant (safe for CI)"
+  exit 0
+fi
 
 # Resolve a workspace package name to its directory (empty if it is not a workspace package)
 dir_for_pkg() {

--- a/.github/scripts/should-run-ci.sh
+++ b/.github/scripts/should-run-ci.sh
@@ -56,45 +56,80 @@ if [ -z "$RESOLVED_BASE_REF" ]; then
   exit 0
 fi
 
-# Helper function to get all dependencies (direct and transitive)
-get_all_deps() {
+# Build an index of workspace packages: one "<package-name> <directory>" record per line.
+# Workspace locations are derived from the root package.json "workspaces" globs, so nested
+# roots (packages/tools/*, packages/plugins/*, and any future ones) are picked up automatically.
+build_workspace_index() {
+  local globs glob dir name
+
+  globs=$(sed -n '/"workspaces"/,/\]/p' package.json 2>/dev/null \
+    | grep -o '"[^"]*"' | tr -d '"' | grep -v '^workspaces$')
+
+  # Fallback to the historical layout if the root manifest can't be parsed
+  if [ -z "$globs" ]; then
+    debug "Warning: could not read workspaces from package.json, falling back to packages/*"
+    globs="packages/*"
+  fi
+
+  for glob in $globs; do
+    for dir in $glob; do
+      [ -f "$dir/package.json" ] || continue
+      name=$(sed -n 's/^[[:space:]]*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" | head -1)
+      [ -n "$name" ] && echo "$name $dir"
+    done
+  done
+}
+
+WORKSPACES=$(build_workspace_index)
+
+# Resolve a workspace package name to its directory (empty if it is not a workspace package)
+dir_for_pkg() {
+  printf '%s\n' "$WORKSPACES" | awk -v n="$1" '$1 == n { print $2; exit }'
+}
+
+# Resolve a workspace directory to its package name (empty if it is not a workspace package)
+name_for_dir() {
+  printf '%s\n' "$WORKSPACES" | awk -v d="$1" '$2 == d { print $1; exit }'
+}
+
+# Collect all workspace dependencies (direct and transitive) into VISITED.
+# VISITED doubles as the loop guard, so cycles terminate the walk instead of being
+# bounded by an arbitrary recursion depth.
+VISITED=""
+
+collect_deps() {
   local pkg=$1
-  local visited=$2
-  local depth=${3:-0}
+  local dir deps dep
 
-  # Limit recursion depth to prevent infinite loops
-  if [ "$depth" -gt 10 ]; then
-    return
-  fi
+  case " $VISITED " in
+    *" $pkg "*) return ;;
+  esac
 
-  # Avoid infinite loops
-  if echo "$visited" | grep -q "^$pkg$"; then
-    return
-  fi
+  VISITED="$VISITED $pkg"
 
-  visited="$visited $pkg"
+  # Packages outside the workspaces (e.g. @editorjs/editorjs, @editorjs/helpers) have no local directory
+  dir=$(dir_for_pkg "$pkg")
+  [ -n "$dir" ] || return
 
-  # Get direct dependencies (if package.json exists)
-  if [ ! -f "packages/$pkg/package.json" ]; then
-    return
-  fi
+  # Every @editorjs/* mention in the manifest counts (dependencies, devDependencies, peerDependencies).
+  # The package's own "name" is matched too, but the loop guard above absorbs it.
+  deps=$(grep -o '"@editorjs/[^"]*"' "$dir/package.json" 2>/dev/null | tr -d '"' | sort -u || true)
 
-  local deps=$(grep -o '"@editorjs/[^"]*"' "packages/$pkg/package.json" 2>/dev/null | sed 's/"//g' | sed 's/@editorjs\///' || true)
-
-  echo "$deps"
-
-  # Recursively get dependencies of dependencies
   for dep in $deps; do
-    get_all_deps "$dep" "$visited" $((depth + 1))
+    collect_deps "$dep"
   done
 }
 
 # Check if this package changed
 # Normalize the package directory path for comparison (remove leading ./)
-NORMALIZED_PKG_DIR=$(echo "$PKG_DIR" | sed 's|^\.\/||')
+NORMALIZED_PKG_DIR=$(echo "$PKG_DIR" | sed 's|^\.\/||' | sed 's|/$||')
 
-# Get the package name for dependency checking
-PKG_NAME=$(basename "$PKG_DIR")
+# Get the package name for dependency checking (directory name is only a fallback)
+PKG_NAME=$(name_for_dir "$NORMALIZED_PKG_DIR")
+if [ -z "$PKG_NAME" ]; then
+  PKG_NAME=$(basename "$NORMALIZED_PKG_DIR")
+  debug "Warning: $NORMALIZED_PKG_DIR is not a known workspace, falling back to name '$PKG_NAME'"
+fi
 
 debug "Checking package: $PKG_NAME (dir: $PKG_DIR)"
 debug "Base ref: $RESOLVED_BASE_REF"
@@ -108,8 +143,9 @@ fi
 
 debug "Package $PKG_NAME has not changed, checking dependencies..."
 
-# Get ALL dependencies (direct and transitive)
-ALL_DEPS=$(get_all_deps "$PKG_NAME" "" 0 | sort -u)
+# Get ALL dependencies (direct and transitive), excluding the package itself
+collect_deps "$PKG_NAME"
+ALL_DEPS=$(printf '%s\n' $VISITED | grep -v "^$PKG_NAME$" | sort -u)
 
 if [ -n "$ALL_DEPS" ]; then
   debug "Dependencies: $(echo $ALL_DEPS | tr '\n' ' ')"
@@ -119,12 +155,9 @@ fi
 
 # Check if any dependency (direct or indirect) changed
 for dep in $ALL_DEPS; do
-  # Map package name to directory - try exact match and underscore variant
-  DEP_DIR=$(find packages -maxdepth 1 -type d \( -name "$dep" -o -name "$(echo $dep | sed 's/-/_/g')" \) 2>/dev/null | head -1)
+  DEP_DIR=$(dir_for_pkg "$dep")
   if [ -n "$DEP_DIR" ]; then
-    # Normalize for git diff output (remove leading ./)
-    NORMALIZED_DEP_DIR=$(echo "$DEP_DIR" | sed 's|^\.\/||')
-    if git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$DEP_DIR" 2>/dev/null | grep -q "^$NORMALIZED_DEP_DIR/"; then
+    if git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$DEP_DIR" 2>/dev/null | grep -q "^$DEP_DIR/"; then
       debug "✓ Dependency $dep (in $DEP_DIR) has changed"
       exit 0
     fi

--- a/.github/scripts/should-run-ci.sh
+++ b/.github/scripts/should-run-ci.sh
@@ -118,7 +118,7 @@ collect_deps() {
 }
 
 # Check if this package changed
-# Normalize the package directory path for comparison (remove leading ./)
+# Normalize the package directory path so it can be matched against yarn's locations
 NORMALIZED_PKG_DIR=$(echo "$PKG_DIR" | sed 's|^\.\/||' | sed 's|/$||')
 
 # Get the package name for dependency checking (directory name is only a fallback)
@@ -131,9 +131,10 @@ fi
 debug "Checking package: $PKG_NAME (dir: $PKG_DIR)"
 debug "Base ref: $RESOLVED_BASE_REF"
 
-GIT_DIFF_OUTPUT=$(git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$PKG_DIR" 2>/dev/null)
-
-if echo "$GIT_DIFF_OUTPUT" | grep -q "^$NORMALIZED_PKG_DIR/"; then
+# `git diff -- <dir>` already restricts its output to that directory, and the pathspec is
+# path-component aware (`-- packages/model` does not match packages/model-types/), so a
+# non-empty result is the answer - no second pass over the paths is needed.
+if [ -n "$(git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$PKG_DIR" 2>/dev/null)" ]; then
   debug "✓ Package $PKG_NAME has changed"
   exit 0
 fi
@@ -154,7 +155,7 @@ fi
 for dep in $ALL_DEPS; do
   DEP_DIR=$(dir_for_pkg "$dep")
   if [ -n "$DEP_DIR" ]; then
-    if git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$DEP_DIR" 2>/dev/null | grep -q "^$DEP_DIR/"; then
+    if [ -n "$(git diff --name-only "$RESOLVED_BASE_REF...HEAD" -- "$DEP_DIR" 2>/dev/null)" ]; then
       debug "✓ Dependency $dep (in $DEP_DIR) has changed"
       exit 0
     fi


### PR DESCRIPTION
Closes #181

## Problem

`.github/scripts/should-run-ci.sh` — the change-detection gate used by `.github/workflows/package-check.yml` — assumed every workspace lives at `packages/<name>`. The root `package.json` declares three workspace roots (`packages/*`, `packages/tools/*`, `packages/plugins/*`), so the dependency fan-out was blind to everything under `packages/plugins/*` and `packages/tools/*`:

- a PR touching `packages/plugins/clipboard-plugin` did **not** re-run `@editorjs/core`'s CI, even though core depends on it;
- a PR touching `packages/sdk` did **not** fan out to the depth-2 plugin/tool CIs.

Each package's *own* CI was unaffected — that path uses the full `working-directory` input.

## Fix

Resolution is driven by a workspace `name -> directory` index built from `yarn workspaces list --json`, as #181 suggested. Yarn is the single source of truth for the layout, so there are no glob-parsing or name-extraction heuristics that can drift from what yarn actually resolves, and a future nesting level cannot reintroduce the original bug.

This runs on a bare `actions/checkout` with **no `yarn install` and no `setup-node`**: the repo vendors yarn 4 at `.yarn/releases/yarn-4.0.1.cjs` via `yarnPath`, and yarn classic 1.22 (preinstalled on `ubuntu-latest`) delegates to it. Confirmed on the runner — see Verification.

The gate **fails open**: if the workspace list can't be produced, CI runs rather than being silently skipped. A false negative here means a package is never validated on the PR, which is much worse than an unnecessary run. Both JSON field orders are parsed for the same reason, so a change in yarn's output ordering degrades to fail-open rather than a wrong skip.

Three further defects in the same code block, fixed along the way:

- **The cycle guard was dead code.** `grep -q "^$pkg$"` ran against a *space-joined* single-line string, so the anchored match could never hit; only the `depth > 10` cap stopped the walk, and re-visits fanned out exponentially. Replaced with a real visited set, which lets the arbitrary depth cap go.
- **The package name was guessed** from `basename` plus an `s/-/_/g` fallback — already wrong for `packages/playground` -> `@editorjs/document-playground`. Now taken from the workspace index.
- **Dependencies were matched by bare suffix**, conflating workspace packages with the external `@editorjs/editorjs` / `@editorjs/helpers` npm deps. Now keyed on the full package name.

Also dropped the `grep -q "^$DIR/"` re-filtering after `git diff --name-only ... -- "$DIR"` (per review): the pathspec already scopes the output, so the second pass only created a way to silently skip CI.

Exit-code contract (`0` = run CI, `1` = skip) is unchanged, and no workflow files are touched.

## Verification

`bash -n` clean. 11 scenarios were run in a throwaway clone, executing the old (`main`) and new script side by side on identical probe commits. All 11 match expectations with the new script; the old one fails 5:

| scenario | expected | old | new |
| --- | --- | --- | --- |
| `plugins/clipboard-plugin` changed -> `core` (issue repro) | run | skip :x: | run :white_check_mark: |
| `sdk` changed -> `tools/paragraph` | run | skip :x: | run :white_check_mark: |
| `sdk` changed -> `plugins/clipboard-plugin` | run | skip :x: | run :white_check_mark: |
| `tools/bold` changed -> `core` | run | skip :x: | run :white_check_mark: |
| trailing-slash target dir | run | skip :x: | run :white_check_mark: |
| transitive: `model` changed -> `core` | run | run :white_check_mark: | run :white_check_mark: |
| own change: `clipboard-plugin` -> itself | run | run :white_check_mark: | run :white_check_mark: |
| **negative:** `ot-server` changed -> `core` | skip | skip :white_check_mark: | skip :white_check_mark: |
| **negative:** `playground` changed -> `core` | skip | skip :white_check_mark: | skip :white_check_mark: |
| **negative:** `core` changed -> `tools/paragraph` | skip | skip :white_check_mark: | skip :white_check_mark: |
| `model` changed -> `playground` (name != dir) | run | run :white_check_mark: | run :white_check_mark: |

The negative cases are the ones that matter — they confirm this isn't an over-broad "always run" fix.

**On a real runner:** because this PR touches only `.github/scripts/`, every package's `should-run` job executes the script on `ubuntu-latest` with nothing but `actions/checkout`. At dccc851 the `lint`/`tests`/`build` jobs were **skipped** for every package, i.e. the script returned `run=false` — an outcome only reachable when the workspace index is non-empty. That is direct evidence that `yarn workspaces list --json` works there with no toolchain setup.

**Fail-open path** was exercised with a stub `yarn` that exits 127: the script exits 0 with `Assuming all changes are relevant (safe for CI)` instead of silently skipping.

The issue's exact repro now passes:

```
$ bash .github/scripts/should-run-ci.sh main ./packages/core --verbose
[DEBUG] Checking package: @editorjs/core (dir: ./packages/core)
[DEBUG] Package @editorjs/core has not changed, checking dependencies...
[DEBUG] Dependencies: @editorjs/bold @editorjs/clipboard-plugin @editorjs/collaboration-manager ...
[DEBUG] ✓ Dependency @editorjs/clipboard-plugin (in packages/plugins/clipboard-plugin) has changed
exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)